### PR TITLE
Fix admin branding

### DIFF
--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -47,7 +47,7 @@ if ( is_network_admin() ) {
 
 if ( $admin_title === $title ) {
 	/* translators: Admin screen title. %s: Admin screen name. */
-	$admin_title = sprintf( __( '%s &#8212; WordPress' ), $title );
+	$admin_title = sprintf( __( '%s &#8212; ClassicPress' ), $title );
 } else {
 	$screen_title = $title;
 
@@ -65,7 +65,7 @@ if ( $admin_title === $title ) {
 	}
 
 	/* translators: Admin screen title. 1: Admin screen name, 2: Network or site name. */
-	$admin_title = sprintf( __( '%1$s &lsaquo; %2$s &#8212; WordPress' ), $screen_title, $admin_title );
+	$admin_title = sprintf( __( '%1$s &lsaquo; %2$s &#8212; ClassicPress' ), $screen_title, $admin_title );
 }
 
 if ( wp_is_recovery_mode() ) {


### PR DESCRIPTION
## Description
 During testing it seems WordPress branding persists in admin pages in the Title HTML paramater which is then displayed in Browsers tabs.

## Motivation and context
Fix ClassicPress branding

## How has this been tested?
Localhost testing

## Screenshots
### Before
<img width="259" alt="Screenshot 2023-04-07 at 14 55 36" src="https://user-images.githubusercontent.com/1280733/230621070-b755060d-c653-4bd7-ba3b-c99de9c2b5a9.png">

### After
<img width="274" alt="Screenshot 2023-04-07 at 14 55 22" src="https://user-images.githubusercontent.com/1280733/230621080-ee0ee050-d27e-4b71-8412-f3d1016e1c17.png">

## Types of changes
- Bug fix
