### PR TITLE
Update version number and dashboard widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ClassicPress",
-  "version": "1.5.2+dev",
+  "version": "2.0+dev",
   "description": "ClassicPress is web software you can use to create a beautiful website or blog.",
   "repository": {
     "type": "git",

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -357,7 +357,7 @@ function update_right_now_message() {
 	 */
 	$content = apply_filters( 'update_right_now_text', $content );
 
-	$msg .= sprintf( '<span id="wp-version">' . $content . '</span>', get_bloginfo( 'version', 'display' ), $theme_name );
+	$msg .= sprintf( '<span id="wp-version">' . $content . '</span>', classicpress_version_short(), $theme_name );
 
 	echo "<p id='wp-version-message'>$msg</p>";
 }

--- a/src/wp-admin/index.php
+++ b/src/wp-admin/index.php
@@ -108,30 +108,10 @@ $screen->add_help_tab(
 
 unset( $help );
 
-$wp_version = get_bloginfo( 'version', 'display' );
-/* translators: %s: ClassicPress version. */
-$wp_version_text = sprintf( __( 'Version %s' ), $wp_version );
-$is_dev_version  = preg_match( '/alpha|beta|RC/', $wp_version );
-
-if ( ! $is_dev_version ) {
-	$version_url = sprintf(
-		/* translators: %s: WordPress version. */
-		esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
-		sanitize_title( $wp_version )
-	);
-
-	$wp_version_text = sprintf(
-		'<a href="%1$s">%2$s</a>',
-		$version_url,
-		$wp_version_text
-	);
-}
-
 $screen->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://wordpress.org/support/article/dashboard-screen/">Documentation on Dashboard</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>' .
-	'<p>' . $wp_version_text . '</p>'
+	'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>'
 );
 
 require_once ABSPATH . 'wp-admin/admin-header.php';

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -27,7 +27,7 @@
  *
  * @global string $cp_version
  */
-$cp_version = '1.5.2+dev';
+$cp_version = '2.0+dev';
 
 /**
  * The WordPress version string.


### PR DESCRIPTION
## Description
In this `v2` branch it can be seen in admin pages that the wrong version number is displayed at the bottom right of the screen.
Also, the base WordPress version is displayed in the `At A Glance` admin dashboard widget.

## Motivation and context
This PR updates the core $cp_version variable definition and also updated the `At A Glance` admin dashboard widget to display the short ClassicPress version.

## How has this been tested?
Localhost testing, see screen shots below

## Screenshots
### Before
Note this reports version as "ClassicPress 6.2"
<img width="464" alt="Screenshot 2023-04-07 at 09 51 32" src="https://user-images.githubusercontent.com/1280733/230621592-e09797cb-b0ca-4704-a6e9-b484ea0a33db.png">

### After
<img width="462" alt="Screenshot 2023-04-07 at 09 52 06" src="https://user-images.githubusercontent.com/1280733/230621600-ca068a13-cf68-4ed7-8d7e-b03b82255c34.png">

## Types of changes
- Bug fix
