### PR TITLE
Fix Dashboard Updates page

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -283,6 +283,8 @@ function core_upgrade_preamble() {
 function list_plugin_updates() {
 	$wp_version     = get_bloginfo( 'version' );
 	$cur_wp_version = preg_replace( '/-.*$/', '', $wp_version );
+	global $cp_version;
+	$cur_cp_version = preg_replace( '/\+.*$/', '', $cp_version );
 
 	require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 	$plugins = get_plugin_updates();
@@ -325,6 +327,13 @@ function list_plugin_updates() {
 
 	<tbody class="plugins">
 	<?php
+
+	$auto_updates = array();
+	if ( wp_is_auto_update_enabled_for_type( 'plugin' ) ) {
+		$auto_updates       = (array) get_site_option( 'auto_update_plugins', array() );
+		$auto_update_notice = ' | ' . wp_get_auto_update_message();
+	}
+
 	foreach ( (array) $plugins as $plugin_file => $plugin_data ) {
 		$plugin_data = (object) _get_plugin_data_markup_translate( $plugin_file, (array) $plugin_data, false, true );
 


### PR DESCRIPTION
Bring back some code from CP-1.x and WP-6.1 in `src/wp-admin/update-core.php`.

## Description
Errors:

```
PHP Fatal error: Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given in .../src/wp-admin/update-core.php:429
PHP Warning: Undefined variable $auto_updates in .../src/wp-admin/update-core.php on line 429
PHP Warning: Undefined variable $cur_cp_version in .../src/wp-admin/update-core.php on line 349
```


## How has this been tested?
MAMP stack and phpunit.

## Screenshots

### Before
<img width="698" alt="Schermata 2023-04-19 alle 13 37 23" src="https://user-images.githubusercontent.com/29772709/233064744-2feac510-3860-4db0-9723-31463043b480.png">


### After
<img width="787" alt="Schermata 2023-04-19 alle 13 41 59" src="https://user-images.githubusercontent.com/29772709/233064771-86ea85bd-dbaf-42a9-964a-889764b92518.png">



## Types of changes
- Bug fix
