### PR TITLE
Fix admin CSS indentation and relative image link

### DIFF
--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -505,17 +505,17 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon:before {
-	background-image: url(/wp-admin/images/classicpress-logo-white.svg?ver=202303);
+	background-image: url(../../wp-admin/images/classicpress-logo-white.svg?ver=202303);
 	background-repeat: no-repeat;
-    background-position: center center;
-    background-size: 100%;
-    top: 6px;
-    content: "";
-    position: absolute;
-    left: 0px;
-    height: 20px;
-    width: 20px;
-    opacity: 0.6;
+	background-position: center center;
+	background-size: 100%;
+	top: 6px;
+	content: "";
+	position: absolute;
+	left: 0px;
+	height: 20px;
+	width: 20px;
+	opacity: 0.6;
 }
 
 /*
@@ -801,7 +801,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar .quicklinks .menupop.hover ul li .ab-item,
 	#wpadminbar.nojs .quicklinks .menupop:hover ul li .ab-item,
 	#wpadminbar .shortlink-input {
-	    line-height: 1.6;
+		line-height: 1.6;
 	}
 
 	#wpadminbar .ab-label {


### PR DESCRIPTION
## Description
As discussed on #21 there are some indentation fixes needed in the admin CSS file.
Also the ClassicPress logo appears only to show for me after editing the link to a relative URL. This needs wider testing and confirmation.

## Motivation and context
Coding standards and branding.

## How has this been tested?
Localhost testing

## Screenshots
### Before
<img width="315" alt="Screenshot 2023-04-23 at 09 56 12" src="https://user-images.githubusercontent.com/1280733/233829992-9178030b-6d9e-4780-ab18-7396fb1a742a.png">
<img width="268" alt="Screenshot 2023-04-23 at 09 56 01" src="https://user-images.githubusercontent.com/1280733/233830009-06813e14-6914-4f58-9883-a3d48345d5ab.png">

### After
<img width="222" alt="Screenshot 2023-04-23 at 09 55 23" src="https://user-images.githubusercontent.com/1280733/233830024-522dbb38-8ba5-4ed7-a8a7-90e6d56e31ca.png">
<img width="262" alt="Screenshot 2023-04-23 at 09 55 43" src="https://user-images.githubusercontent.com/1280733/233830030-71847041-8bb0-48d9-b896-e6647def8cf9.png">

## Types of changes
- Bug fix
