### PR TITLE
Ensure tests run on develop on merge and schedule

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -24,7 +24,7 @@ jobs:
   phpcs:
     name: PHP coding standards
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'ClassicPress/ClassicPress-v2' || github.event_name == 'pull_request' }}
 
     steps:
       - name: Checkout repository
@@ -72,7 +72,7 @@ jobs:
   precommit:
     name: Pre-commit checks
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'ClassicPress/ClassicPress-v2' || github.event_name == 'pull_request' }}
     env:
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
 

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -22,7 +22,7 @@ jobs:
   test-js:
     name: QUnit Tests
     runs-on: ubuntu-20.04
-    if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'ClassicPress/ClassicPress-v2' || github.event_name == 'pull_request' }}
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -25,7 +25,7 @@ jobs:
   php-comatibility:
     name: Check PHP compatibility
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'ClassicPress/ClassicPress-v2' || github.event_name == 'pull_request' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -35,7 +35,7 @@ jobs:
   test-php:
     name: "PHP ${{ matrix.php }}${{ matrix.memcached && ' with memcached' || '' }}${{ matrix.experimental && ' - Experimental' || '' }}"
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'ClassicPress/ClassicPress-v2' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description
To protect against excessive testing some of the GitHub Action configuration files check we are in the correct repository. This is currently using the repository names for ClassicPress 1.x branch, it needs the name amending to ensure tests run when we merge to develop and also on the weekly schedule.

## Motivation and context
Tests are currently not running.

## How has this been tested?
Tests will run against this PR but we can only be sure this helps once merged to develop.

## Screenshots
N/A

## Types of changes
- Bug fix
