### PR TITLE
Fix: Filters on refresh nonces

### DIFF
--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -78,7 +78,6 @@ add_filter( 'heartbeat_received', 'wp_refresh_post_lock', 10, 3 );
 add_filter( 'heartbeat_received', 'heartbeat_autosave', 500, 2 );
 
 add_filter( 'wp_refresh_nonces', 'wp_refresh_post_nonces', 10, 3 );
-add_filter( 'wp_refresh_nonces', 'wp_refresh_metabox_loader_nonces', 10, 2 );
 add_filter( 'wp_refresh_nonces', 'wp_refresh_heartbeat_nonces' );
 
 add_filter( 'heartbeat_settings', 'wp_heartbeat_set_suspension' );

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1319,6 +1319,24 @@ function wp_refresh_post_nonces( $response, $data, $screen_id ) {
 }
 
 /**
+ * Adds the latest Heartbeat and REST-API nonce to the Heartbeat response.
+ *
+ * @since 5.0.0
+ *
+ * @param array $response The Heartbeat response.
+ * @return array The Heartbeat response.
+ */
+function wp_refresh_heartbeat_nonces( $response ) {
+	// Refresh the Rest API nonce.
+	$response['rest_nonce'] = wp_create_nonce( 'wp_rest' );
+
+	// Refresh the Heartbeat nonce.
+	$response['heartbeat_nonce'] = wp_create_nonce( 'heartbeat-nonce' );
+
+	return $response;
+}
+
+/**
  * Disable suspension of Heartbeat on the Add/Edit Post screens.
  *
  * @since 3.8.0


### PR DESCRIPTION
## Description
While testing the code on a live site I noted that filter calls to `wp_refresh_metabox_loader_nonces` were being logged in the error log, this function is missing in the code base and applies only to the Block Editor, so the filter needs removing.

Also, we are missing the `wp_refresh_heartbeat_nonces` function, that seems more broadly used so I have back ported it on this PR, it will avoid a similar issue.

## Motivation and context
Described above - avoids error logging.

## How has this been tested?
Local house testing.

## Screenshots
N/A

## Types of changes
- Bug fix
