### PR TITLE
Revert unnecessary string translation change

### DIFF
--- a/src/wp-admin/index.php
+++ b/src/wp-admin/index.php
@@ -111,7 +111,7 @@ unset( $help );
 $screen->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://wordpress.org/support/article/dashboard-screen/">Documentation on Dashboard</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>'
+	'<p>' . __( '<a href="https://wordpress.org/support/forums/">Support forums</a>' ) . '</p>'
 );
 
 require_once ABSPATH . 'wp-admin/admin-header.php';


### PR DESCRIPTION
## Description
As noted in the comment here:
https://github.com/ClassicPress/ClassicPress-v2/pull/20

## Motivation and context
We have an amended support forum string that we are already handling via a `gettext` filter.

## How has this been tested?
Local host testing ensured URL is still translated to the correct location.

## Screenshots
N/A

## Types of changes
- Bug fix
