### PR TITLE
Remove Block code from Privacy content class

### DIFF
--- a/src/wp-admin/includes/class-wp-privacy-policy-content.php
+++ b/src/wp-admin/includes/class-wp-privacy-policy-content.php
@@ -336,39 +336,22 @@ final class WP_Privacy_Policy_Content {
 		$url     = esc_url( admin_url( 'options-privacy.php?tab=policyguide' ) );
 		$label   = __( 'View Privacy Policy Guide.' );
 
-		if ( get_current_screen()->is_block_editor() ) {
-			wp_enqueue_script( 'wp-notices' );
-			$action = array(
-				'url'   => $url,
-				'label' => $label,
-			);
-			wp_add_inline_script(
-				'wp-notices',
-				sprintf(
-					'wp.data.dispatch( "core/notices" ).createWarningNotice( "%s", { actions: [ %s ], isDismissible: false } )',
-					$message,
-					wp_json_encode( $action )
-				),
-				'after'
-			);
-		} else {
-			?>
-			<div class="notice notice-warning inline wp-pp-notice">
-				<p>
-				<?php
-				echo $message;
-				printf(
-					' <a href="%s" target="_blank">%s <span class="screen-reader-text">%s</span></a>',
-					$url,
-					$label,
-					/* translators: Hidden accessibility text. */
-					__( '(opens in a new tab)' )
-				);
-				?>
-				</p>
-			</div>
+		?>
+		<div class="notice notice-warning inline wp-pp-notice">
+			<p>
 			<?php
-		}
+			echo $message;
+			printf(
+				' <a href="%s" target="_blank">%s <span class="screen-reader-text">%s</span></a>',
+				$url,
+				$label,
+				/* translators: Hidden accessibility text. */
+				__( '(opens in a new tab)' )
+			);
+			?>
+			</p>
+		</div>
+		<?php
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-privacy-policy-content.php
+++ b/src/wp-admin/includes/class-wp-privacy-policy-content.php
@@ -450,7 +450,7 @@ final class WP_Privacy_Policy_Content {
 	 * @param bool $blocks      Whether to format the content for the block editor. Default true.
 	 * @return string The default policy content.
 	 */
-	public static function get_default_content( $description = false, $blocks = true ) {
+	public static function get_default_content( $description = false, $blocks = false ) {
 		$suggested_text = '<strong class="privacy-policy-tutorial">' . __( 'Suggested text:' ) . ' </strong>';
 		$content        = '';
 		$strings        = array();
@@ -652,18 +652,6 @@ final class WP_Privacy_Policy_Content {
 			/* translators: Privacy policy tutorial. */
 			$strings[] = '<p class="privacy-policy-tutorial">' . __( 'If you are a member of a regulated industry, or if you are subject to additional privacy laws, you may be required to disclose that information here.' ) . '</p>';
 			$strings[] = '</div>';
-		}
-
-		if ( $blocks ) {
-			foreach ( $strings as $key => $string ) {
-				if ( 0 === strpos( $string, '<p>' ) ) {
-					$strings[ $key ] = '<!-- wp:paragraph -->' . $string . '<!-- /wp:paragraph -->';
-				}
-
-				if ( 0 === strpos( $string, '<h2>' ) ) {
-					$strings[ $key ] = '<!-- wp:heading -->' . $string . '<!-- /wp:heading -->';
-				}
-			}
 		}
 
 		$content = implode( '', $strings );


### PR DESCRIPTION
## Description
Partially addresses #40

## Motivation and context
As per Issued #40, there are Block code fragments that need review and removal.
These changes affect `src/wp-admin/includes/class-wp-privacy-policy-content.php`

## How has this been tested?
Will need testing

## Screenshots
N/A

## Types of changes
- Code Enhancement
