### PR TITLE
Core plugins - proposal

### DIFF
--- a/src/wp-includes/classicpress/class-cp-customization.php
+++ b/src/wp-includes/classicpress/class-cp-customization.php
@@ -8,9 +8,36 @@
  */
 
 class CP_Customization {
+	/**
+	 * Stores ClassicPress core plugins list.
+	 * @var array
+	 */
+	public $cp_core_plugins = array(
+		'codepotent-update-manager/codepotent-update-manager.php',
+		'aaa.php',
+	);
+
 	public function __construct() {
 		add_action( 'load-edit.php', array( $this, 'add_id_init' ) );
 		add_filter( 'gettext_default', array( $this, 'cp_translations' ), 10, 3 );
+		add_filter( 'option_active_plugins', array( $this, 'cp_sort_plugins' ) );
+	}
+
+	/**
+	 * Sorts a list of plugin slugs putting core plugin first.
+	 *
+	 * Intended to be used as option_active_plugins filter.
+	 *
+	 * @since CP-2.0.0
+	 *
+	 *
+	 * @param array $active_plugins
+	 * @return array
+	 */
+	public function cp_sort_plugins( $active_plugins ) {
+		$active_core_plugins = array_intersect( $this->cp_core_plugins, $active_plugins );
+		$plugin_list = array_values( array_unique( array_merge( $active_core_plugins, $active_plugins ) ) );
+		return $plugin_list;
 	}
 
 	/**

--- a/src/wp-includes/classicpress/class-cp-customization.php
+++ b/src/wp-includes/classicpress/class-cp-customization.php
@@ -13,8 +13,7 @@ class CP_Customization {
 	 * @var array
 	 */
 	public $cp_core_plugins = array(
-		'codepotent-update-manager/codepotent-update-manager.php',
-		'aaa.php',
+		'classicpress-directory-integration/classicpress-directory-integration.php',
 	);
 
 	public function __construct() {
@@ -36,7 +35,7 @@ class CP_Customization {
 	 */
 	public function cp_sort_plugins( $active_plugins ) {
 		$active_core_plugins = array_intersect( $this->cp_core_plugins, $active_plugins );
-		$plugin_list = array_values( array_unique( array_merge( $active_core_plugins, $active_plugins ) ) );
+		$plugin_list         = array_values( array_unique( array_merge( $active_core_plugins, $active_plugins ) ) );
 		return $plugin_list;
 	}
 

--- a/tests/phpunit/data/plugins/core1.php
+++ b/tests/phpunit/data/plugins/core1.php
@@ -1,0 +1,4 @@
+<?php
+/*
+Plugin Name: Core Plugin 1
+*/

--- a/tests/phpunit/data/plugins/core2.php
+++ b/tests/phpunit/data/plugins/core2.php
@@ -1,0 +1,4 @@
+<?php
+/*
+Plugin Name: Core Plugin 2
+*/

--- a/tests/phpunit/tests/admin/corePlugins.php
+++ b/tests/phpunit/tests/admin/corePlugins.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @group plugins
+ * @group admin
+ */
+class Tests_Admin_CorePlugins extends WP_UnitTestCase {
+	public function test_core_plugins_load_order() {
+		$core1_dir = WP_PLUGIN_DIR . '/core1';
+		mkdir( $core1_dir );
+		$core1 = $this->_create_plugin( "<?php\n/*\n* Plugin Name: YOUR PLUGIN NAME\n*/\n", 'core1.php', WP_PLUGIN_DIR . '/core1' );
+		$core2_dir = WP_PLUGIN_DIR . '/core2';
+		mkdir( $core2_dir );
+		$core2 = $this->_create_plugin( "<?php\n/*\n* Plugin Name: YOUR PLUGIN NAME\n*/\n", 'core2.php', WP_PLUGIN_DIR . '/core2' );
+
+		activate_plugin( 'core1/core1.php' );
+		activate_plugin( 'hello.php' );
+		activate_plugin( 'core2/core2.php' );
+
+		global $cp_customization;
+		$cp_customization->cp_core_plugins = array(
+			'core2/core2.php',
+			'core1/core1.php',
+		);
+
+		$expected_order = array(
+			'core2/core2.php',
+			'core1/core1.php',
+			'hello.php',
+		);
+		$active_order = get_option( 'active_plugins' );
+		$this->assertEquals( $expected_order, $active_order );
+
+		remove_filter( 'option_active_plugins', array( $cp_customization, 'cp_sort_plugins' ) );
+		$active_order = get_option( 'active_plugins' );
+		$this->assertNotEquals( $expected_order, $active_order );
+
+		unlink( $core1[1] );
+		rmdir( $core1_dir );
+		unlink( $core2[1] );
+		rmdir( $core2_dir );
+	}
+
+	private function _create_plugin( $data = "<?php\n/*\nPlugin Name: Test\n*/", $filename = false, $dir_path = false ) {
+		if ( false === $filename ) {
+			$filename = __FUNCTION__ . '.php';
+		}
+
+		if ( false === $dir_path ) {
+			$dir_path = WP_PLUGIN_DIR;
+		}
+
+		$filename  = wp_unique_filename( $dir_path, $filename );
+		$full_name = $dir_path . '/' . $filename;
+
+		$file = fopen( $full_name, 'w' );
+		fwrite( $file, $data );
+		fclose( $file );
+
+		return array( $filename, $full_name );
+	}
+}

--- a/tests/phpunit/tests/admin/corePlugins.php
+++ b/tests/phpunit/tests/admin/corePlugins.php
@@ -5,26 +5,19 @@
  */
 class Tests_Admin_CorePlugins extends WP_UnitTestCase {
 	public function test_core_plugins_load_order() {
-		$core1_dir = WP_PLUGIN_DIR . '/core1';
-		mkdir( $core1_dir );
-		$core1 = $this->_create_plugin( "<?php\n/*\n* Plugin Name: YOUR PLUGIN NAME\n*/\n", 'core1.php', WP_PLUGIN_DIR . '/core1' );
-		$core2_dir = WP_PLUGIN_DIR . '/core2';
-		mkdir( $core2_dir );
-		$core2 = $this->_create_plugin( "<?php\n/*\n* Plugin Name: YOUR PLUGIN NAME\n*/\n", 'core2.php', WP_PLUGIN_DIR . '/core2' );
-
-		activate_plugin( 'core1/core1.php' );
+		activate_plugin( 'core1.php' );
 		activate_plugin( 'hello.php' );
-		activate_plugin( 'core2/core2.php' );
+		activate_plugin( 'core2.php' );
 
 		global $cp_customization;
 		$cp_customization->cp_core_plugins = array(
-			'core2/core2.php',
-			'core1/core1.php',
+			'core2.php',
+			'core1.php',
 		);
 
 		$expected_order = array(
-			'core2/core2.php',
-			'core1/core1.php',
+			'core2.php',
+			'core1.php',
 			'hello.php',
 		);
 		$active_order = get_option( 'active_plugins' );
@@ -33,29 +26,5 @@ class Tests_Admin_CorePlugins extends WP_UnitTestCase {
 		remove_filter( 'option_active_plugins', array( $cp_customization, 'cp_sort_plugins' ) );
 		$active_order = get_option( 'active_plugins' );
 		$this->assertNotEquals( $expected_order, $active_order );
-
-		unlink( $core1[1] );
-		rmdir( $core1_dir );
-		unlink( $core2[1] );
-		rmdir( $core2_dir );
-	}
-
-	private function _create_plugin( $data = "<?php\n/*\nPlugin Name: Test\n*/", $filename = false, $dir_path = false ) {
-		if ( false === $filename ) {
-			$filename = __FUNCTION__ . '.php';
-		}
-
-		if ( false === $dir_path ) {
-			$dir_path = WP_PLUGIN_DIR;
-		}
-
-		$filename  = wp_unique_filename( $dir_path, $filename );
-		$full_name = $dir_path . '/' . $filename;
-
-		$file = fopen( $full_name, 'w' );
-		fwrite( $file, $data );
-		fclose( $file );
-
-		return array( $filename, $full_name );
 	}
 }


### PR DESCRIPTION
## Description
**This is a proposal to add "Core Plugins".**

Core plugins are normal plugins developed by ClassicPress that are used to expand or restore core functionality.
The only difference is that they may need to be loaded before the others.
So this PR adds to core a list of core plugins (for now just ClassicPress Directory Integration) and make sure that plugins in that list are loaded first.

## How has this been tested?
Unit tests cover:
- that the hook is in place
- that the order is happening correctly

## Types of changes
- New feature
