### PR TITLE
Ensure src jQuery UI and TinyMCE files included in build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,8 +140,6 @@ module.exports = function(grunt) {
 							'!wp-includes/js/backbone.js',
 							'!wp-includes/js/underscore.js',
 							'!wp-includes/js/jquery/jquery.masonry.js',
-							'!wp-includes/js/jquery/ui/*.js',
-							'!wp-includes/js/tinymce/tinymce.js',
 							// Exclude some things present in a configured install
 							'!wp-config.php',
 							'!wp-content/uploads/**',


### PR DESCRIPTION
## Description
Original source files for jQuery UI and TinyMCE are not included in the ClassicPress v2 final build.

## Motivation and context
In testing and as reported in #66, absence of these files is causing 404 errors if `SCRIPT_DEBUG` is defined as true.

This PR amends the build process that copies source files and removes lines that skip thee files detailed above for copying.

## How has this been tested?
Local testing looking in the `build/wp-includes/js/jquery/ui/` folder to ensure unminified files are not currently included before this PR, and to ensure that they are included after this PR.

Local PHPUnit tests are passing.

## Screenshots
N/A

## Types of changes
- Bug fix
- Fixes #66