### PR TITLE
Add using_block_function hook

### DIFF
--- a/src/wp-includes/classicpress/class-wp-compat.php
+++ b/src/wp-includes/classicpress/class-wp-compat.php
@@ -198,6 +198,15 @@ class WP_Compat {
 
 		$trace = debug_backtrace();
 
+		/*
+		 * Fires after WP_Compat::using_block_function() is called.
+		 *
+		 * @since: CP-2.0.0
+		 *
+		 * @param array $trace debug_backtrace() output
+		 */
+		do_action( 'using_block_function', $trace );
+
 		if ( 0 === strpos( $trace[1]['file'], realpath( get_stylesheet_directory() ) ) ) {
 			// Current theme is calling the function
 			update_option( 'theme_using_blocks', '1' );

--- a/src/wp-includes/classicpress/class-wp-compat.php
+++ b/src/wp-includes/classicpress/class-wp-compat.php
@@ -64,7 +64,7 @@ class WP_Compat {
 		?>
 		<tr class="plugin-update-tr <?php echo $active; ?>">
 			<td colspan="<?php echo $wp_list_table->get_column_count(); ?>" class="plugin-update colspanchange" <?php echo $shadow; ?>>
-				<div class="notice inline notice-alt notice-warning">
+				<div class="notice inline notice-warning">
 					<p>
 						<?php
 						// Translators: %1$s is the plugin name.
@@ -155,7 +155,7 @@ class WP_Compat {
 		}
 
 		?>
-		<div class="notice notice-alt notice-warning">
+		<div class="notice notice-warning">
 			<p>
 			<?php
 				echo $message;


### PR DESCRIPTION
To be able to investigate more deeply plugins and themes using block functions covered by polyfills a new hook is in place:
the action `using_block_function` fires if Block Compatibility is in "Debugging" level.

## Description
```php
add_action( 'using_block_function', 'my_function', 10, 1 );
function my_function ( $trace ) {
   trigger_error( print_r( $trace, true ) );
}
```

This code snippet allows to get the content of `debug_backtrace()` that is called in `WP_Compat::using_block_function()`.

## How has this been tested?
Local testing using the above snippet.

## Types of changes
- New feature

