### PR TITLE
Branding fixes for Site Health and Installation

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -64,23 +64,13 @@ class WP_Debug_Data {
 		// Set up the array that holds all debug information.
 		$info = array();
 
-		$info['classicpress'] = array(
-			'label'  => __( 'ClassicPress' ),
-			'fields' => array(
-				'platform' => array(
-					'label' => __( '** Platform **' ),
-					'value' => $core_version,
-				),
-			),
-		);
-
 		$info['wp-core'] = array(
 			'label'  => __( 'ClassicPress' ),
 			'fields' => array(
 				'version'                => array(
 					'label' => __( 'Version' ),
 					'value' => $core_version . $core_update_needed,
-					'debug' => $core_version,
+					'debug' => '**' . __( 'ClassicPress' ) . '** ' . $core_version,
 				),
 				'site_language'          => array(
 					'label' => __( 'Site Language' ),

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -46,7 +46,7 @@ class WP_Debug_Data {
 		$blog_public            = get_option( 'blog_public' );
 		$default_comment_status = get_option( 'default_comment_status' );
 		$environment_type       = wp_get_environment_type();
-		$core_version           = classicpress_version();
+		$core_version           = classicpress_version() . ' (WP-' . get_bloginfo( 'version' ) . ')';
 		$core_updates           = get_core_updates();
 		$core_update_needed     = '';
 
@@ -63,6 +63,16 @@ class WP_Debug_Data {
 
 		// Set up the array that holds all debug information.
 		$info = array();
+
+		$info['classicpress'] = array(
+			'label'  => __( 'ClassicPress' ),
+			'fields' => array(
+				'platform' => array(
+					'label' => __( '** Platform **' ),
+					'value' => $core_version,
+				),
+			),
+		);
 
 		$info['wp-core'] = array(
 			'label'  => __( 'ClassicPress' ),

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -46,7 +46,7 @@ class WP_Debug_Data {
 		$blog_public            = get_option( 'blog_public' );
 		$default_comment_status = get_option( 'default_comment_status' );
 		$environment_type       = wp_get_environment_type();
-		$core_version           = get_bloginfo( 'version' );
+		$core_version           = classicpress_version();
 		$core_updates           = get_core_updates();
 		$core_update_needed     = '';
 
@@ -346,7 +346,7 @@ class WP_Debug_Data {
 			'label'       => __( 'Filesystem Permissions' ),
 			'description' => __( 'Shows whether ClassicPress is able to write to the directories it needs access to.' ),
 			'fields'      => array(
-				'wordpress'  => array(
+				'root'  => array(
 					'label' => __( 'The main ClassicPress directory' ),
 					'value' => ( $is_writable_abspath ? __( 'Writable' ) : __( 'Not writable' ) ),
 					'debug' => ( $is_writable_abspath ? 'writable' : 'not writable' ),
@@ -411,11 +411,11 @@ class WP_Debug_Data {
 			$loading = __( 'Loading&hellip;' );
 
 			$info['wp-paths-sizes']['fields'] = array(
-				'wordpress_path' => array(
+				'classicpress_path' => array(
 					'label' => __( 'ClassicPress directory location' ),
 					'value' => untrailingslashit( ABSPATH ),
 				),
-				'wordpress_size' => array(
+				'classicpress_size' => array(
 					'label' => __( 'ClassicPress directory size' ),
 					'value' => $loading,
 					'debug' => 'loading...',
@@ -1592,14 +1592,14 @@ class WP_Debug_Data {
 		// Go through the various installation directories and calculate their sizes.
 		// No trailing slashes.
 		$paths = array(
-			'wordpress_size' => untrailingslashit( ABSPATH ),
+			'classicpress_size' => untrailingslashit( ABSPATH ),
 			'themes_size'    => get_theme_root(),
 			'plugins_size'   => WP_PLUGIN_DIR,
 			'uploads_size'   => $upload_dir['basedir'],
 		);
 
 		$exclude = $paths;
-		unset( $exclude['wordpress_size'] );
+		unset( $exclude['classicpress_size'] );
 		$exclude = array_values( $exclude );
 
 		$size_total = 0;
@@ -1614,7 +1614,7 @@ class WP_Debug_Data {
 			);
 
 			if ( microtime( true ) - WP_START_TIMESTAMP < $max_execution_time ) {
-				if ( 'wordpress_size' === $name ) {
+				if ( 'classicpress_size' === $name ) {
 					$dir_size = recurse_dirsize( $path, $exclude, $max_execution_time );
 				} else {
 					$dir_size = recurse_dirsize( $path, null, $max_execution_time );

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -833,7 +833,7 @@ class WP_Site_Health {
 				__( 'PHP modules perform most of the tasks on the server that make your site run. Any changes to these must be made by your server administrator.' ),
 				sprintf(
 					/* translators: 1: Link to the hosting group page about recommended PHP modules. 2: Additional link attributes. 3: Accessibility text. */
-					__( 'The ClassicPress Hosting Team maintains a list of those modules, both recommended and required, in <a href="%1$s" %2$s>the team handbook%3$s</a>.' ),
+					__( 'ClassicPress maintains a list of those modules, both recommended and required, in <a href="%1$s" %2$s>the server requirements%3$s</a>.' ),
 					/* translators: Localized team handbook, if one exists. */
 					esc_url( __( 'https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions' ) ),
 					'target="_blank" rel="noopener"',

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1374,7 +1374,7 @@ class WP_Site_Health {
 		);
 
 		$wp_dotorg = wp_remote_get(
-			'http://api-v1.classicpress.net',
+			'https://api-v1.classicpress.net',
 			array(
 				'timeout' => 10,
 			)

--- a/src/wp-admin/install.php
+++ b/src/wp-admin/install.php
@@ -70,11 +70,11 @@ function display_header( $body_classes = '' ) {
 	<meta name="viewport" content="width=device-width" />
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta name="robots" content="noindex,nofollow" />
-	<title><?php _e( 'WordPress &rsaquo; Installation' ); ?></title>
+	<title><?php _e( 'ClassicPress &rsaquo; Installation' ); ?></title>
 	<?php wp_admin_css( 'install', true ); ?>
 </head>
 <body class="wp-core-ui<?php echo $body_classes; ?>">
-<p id="logo"><?php _e( 'WordPress' ); ?></p>
+<p id="logo"><?php _e( 'ClassicPress' ); ?></p>
 
 	<?php
 } // End display_header().
@@ -212,7 +212,7 @@ function display_setup_form( $error = null ) {
 			</td>
 		</tr>
 	</table>
-	<p class="step"><?php submit_button( __( 'Install WordPress' ), 'large', 'Submit', false, array( 'id' => 'submit' ) ); ?></p>
+	<p class="step"><?php submit_button( __( 'Install ClassicPress' ), 'large', 'Submit', false, array( 'id' => 'submit' ) ); ?></p>
 	<input type="hidden" name="language" value="<?php echo isset( $_REQUEST['language'] ) ? esc_attr( $_REQUEST['language'] ) : ''; ?>" />
 </form>
 	<?php


### PR DESCRIPTION
## Description
This PR fixes some branding issues seen during new installation and in the Site Health admin page, fixes #76 

## Motivation and context
Removes reference to "WordPress" and gives more clarity to Site Health as ClassicPress sites.

## How has this been tested?
Local testing only

## Screenshots
N/A, will need visual checks.

## Types of changes
- Bug fix
