### PR TITLE
Fix deprecation when saving general options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
 		"backport": "bin/backport-wp-commit.sh",
 		"phpcs": "vendor/bin/phpcs -n",
 		"phpcs-tests": "vendor/bin/phpcs -n tests",
-		"phpunit": "vendor/bin/phpunit"
+		"phpunit": "vendor/bin/phpunit",
+		"phpcompat": "vendor/bin/phpcs --standard=phpcompat.xml.dist"
 	}
 }

--- a/phpcompat.xml.dist
+++ b/phpcompat.xml.dist
@@ -5,8 +5,8 @@
 	<!-- Use PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibilityWP"/>
 
-	<!-- ClassicPress Core currently supports PHP 5.6+. -->
-	<config name="testVersion" value="5.6-"/>
+	<!-- ClassicPress Core currently supports PHP 7.4+. -->
+	<config name="testVersion" value="7.4-"/>
 
 	<!-- Only scan PHP files. -->
 	<arg name="extensions" value="php"/>

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4884,7 +4884,7 @@ function sanitize_option( $option, $value ) {
 			break;
 
 		case 'gmt_offset':
-			$value = preg_replace( '/[^0-9:.-]/', '', $value ); // Strips slashes.
+			$value = preg_replace( '/[^0-9:.-]/', '', $value ?? '' ); // Strips slashes.
 			break;
 
 		case 'siteurl':

--- a/tests/phpunit/tests/option/sanitizeOption.php
+++ b/tests/phpunit/tests/option/sanitizeOption.php
@@ -37,6 +37,7 @@ class Tests_Option_SanitizeOption extends WP_UnitTestCase {
 			array( 'ping_sites', "http://www.example.com\nhttp://example.org", "www.example.com \n\texample.org\n\n" ),
 			array( 'gmt_offset', '0', 0 ),
 			array( 'gmt_offset', '1.5', '1.5' ),
+			array( 'gmt_offset', '', null ),
 			array( 'siteurl', 'http://example.org', 'http://example.org' ),
 			array( 'siteurl', 'http://example.org/subdir', 'http://example.org/subdir' ),
 			array( 'siteurl', get_option( 'siteurl' ), '' ),


### PR DESCRIPTION
Closes issue #11.

## Description
Use the null coalesce operator to ensure that when an undefined `gmt_offset` is passed to `sanitize_option` the regular expression is not working on a `null` value.

## Motivation and context
- There is a [PR from WordPress](https://github.com/WordPress/wordpress-develop/pull/4082) but that one breaks other options.  
- Unit tests in the change suggested by Sergey Biryukov in [this trac ticket](https://core.trac.wordpress.org/ticket/57728) are failing.

So we can fix this by our own solution.

## How has this been tested?
Unit tests passing and added a specific check.

## Types of changes
- Bug fix
