### PR TITLE
fix: Changed wording for block compat notices

### DIFF
--- a/src/wp-includes/classicpress/class-wp-compat.php
+++ b/src/wp-includes/classicpress/class-wp-compat.php
@@ -68,8 +68,9 @@ class WP_Compat {
 					<p>
 						<?php
 						// Translators: %1$s is the plugin name.
-						printf( esc_html__( '%1$s uses block-related functions and may not work correctly.' ), $plugin_data['Name'] );
+						printf( esc_html__( '%1$s uses block-related functions and may have issues.' ), $plugin_data['Name'] );
 						?>
+						<a href="https://docs.classicpress.net/user-guides/using-classicpress/settings-general-screen/#blocks-compatibility"><?php _e( 'Learn more' ); ?></a> | 
 						<a href="https://forums.classicpress.net/new-topic?category=plugins/plugin-support&tags=blocks-compatibility&title=<?php echo urlencode( $plugin_data['Name'] ); ?>+blocks+compatibility"><?php _e( 'Report an issue &rsaquo;' ); ?></a>
 					</p>
 				</div>
@@ -146,11 +147,13 @@ class WP_Compat {
 
 		if ( '1' === $theme_using_blocks ) {
 			// Translators: %1$s is the theme name.
-			$message  = sprintf( esc_html__( '%1$s uses block-related functions and may not work correctly.' ), wp_get_theme()->get( 'Name' ) );
+			$message  = sprintf( esc_html__( '%1$s uses block-related functions and may have issues.' ), wp_get_theme()->get( 'Name' ) );
+			$message .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/settings-general-screen/#blocks-compatibility">' . __( 'Learn more' ) . '</a> |';
 			$message .= ' <a href="https://forums.classicpress.net/new-topic?category=themes/theme-support&tags=blocks-compatibility&title=' . urlencode( wp_get_theme()->get( 'Name' ) ) . '+blocks+compatibility">' . __( 'Report an issue &rsaquo;' ) . '</a>';
 		} else {
 			// Translators: %1$s is the theme name, %1$s is the parent theme name.
-			$message = sprintf( esc_html__( '%1$s parent theme (%2$s) uses block-related functions and may not work correctly.' ), wp_get_theme()->get( 'Name' ), wp_get_theme()->parent()->get( 'Name' ) );
+			$message = sprintf( esc_html__( '%1$s parent theme (%2$s) uses block-related functions and may have issues.' ), wp_get_theme()->get( 'Name' ), wp_get_theme()->parent()->get( 'Name' ) );
+			$message .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/settings-general-screen/#blocks-compatibility">' . __( 'Learn more' ) . '</a> |';
 			$message .= ' <a href="https://forums.classicpress.net/new-topic?category=themes/theme-support&tags=blocks-compatibility&title=' . urlencode( wp_get_theme()->parent()->get( 'Name' ) ) . '+blocks+compatibility">' . __( 'Report an issue &rsaquo;' ) . '</a>';
 		}
 


### PR DESCRIPTION
## Description
Changed wording of block compatibility notices and added learn more link.

## Motivation and context
"may not work correctly" is too strong of a statement, so I changed it to be a bit more friendlier "may have issues". I also added learn more links to the notices as people will have questions about them.

## How has this been tested?
Locally.

## Screenshots
![image](https://github.com/ClassicPress/ClassicPress-v2/assets/1692600/998671c1-f772-4a85-9a91-7eab0c0f5c16)

