### PR TITLE
Add noreferrer to gravatar link

### DIFF
--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -596,7 +596,7 @@ switch ( $action ) {
 									if ( IS_PROFILE_PAGE ) {
 										$description = sprintf(
 											/* translators: %s: Gravatar URL. */
-											__( '<a href="%s">You can change your profile picture on Gravatar</a>.' ),
+											__( '<a href="%s" rel="noreferrer">You can change your profile picture on Gravatar</a>.' ),
 											__( 'https://en.gravatar.com/' )
 										);
 									} else {


### PR DESCRIPTION
## Description
Fixes #93 

## Motivation and context
Adds "noreferrer" to link to Gravatar from Profile page, for privacy purposes.

## How has this been tested?
Basic change

## Screenshots
N/A

## Types of changes
- Enhancement
