### PR TITLE
Fix tab display in Add Plugins

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1373,6 +1373,24 @@ th.action-links {
 	}
 }
 
+/* Plugin Search Categories filter */
+.plugin-categories-filter {
+	display: inline-block;
+}
+.plugin-categories-filter li {
+	background-color: #FFF;
+	border: 1px solid #DDD;
+	float: left;
+	padding: 20px;
+	width: 21.5%;
+}
+.plugin-categories-filter li {
+	margin-right: 5px;
+}
+.plugin-categories-filter li a {
+	font-size: 1.5em;
+}
+
 /*------------------------------------------------------------------------------
   4.0 - Notifications
 ------------------------------------------------------------------------------*/

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1378,17 +1378,19 @@ th.action-links {
 	display: inline-block;
 }
 .plugin-categories-filter li {
-	background-color: #FFF;
-	border: 1px solid #DDD;
 	float: left;
-	padding: 20px;
 	width: 21.5%;
-}
-.plugin-categories-filter li {
-	margin-right: 5px;
 }
 .plugin-categories-filter li a {
 	font-size: 1.5em;
+	background-color: #FFF;
+	border: 1px solid #c3c4c7;
+	padding: 20px;
+	display: block;
+	text-decoration: none;
+}
+.plugin-categories-filter li a:hover, .plugin-categories-filter li a:focus {
+	background-color: #f6f7f7;
 }
 
 /*------------------------------------------------------------------------------
@@ -3123,7 +3125,7 @@ img {
 .postbox .handle-order-higher .order-higher-indicator::before,
 .postbox .handle-order-lower .order-lower-indicator::before {
 	position: relative;
-    top: 0.11rem;
+	top: 0.11rem;
 	width: 20px;
 	height: 20px;
 }

--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -89,14 +89,10 @@ add_action( 'admin_head-nav-menus.php', '_wp_delete_orphaned_draft_menu_items' )
 add_filter( 'allowed_options', 'option_update_filter' );
 
 // Plugin Install hooks.
-add_action( 'install_plugins_featured', 'install_dashboard' );
+add_action( 'install_plugins_popular', 'install_dashboard' );
+add_action( 'install_plugins_categories', 'display_plugins_categories_list' );
 add_action( 'install_plugins_upload', 'install_plugins_upload' );
 add_action( 'install_plugins_search', 'display_plugins_table' );
-add_action( 'install_plugins_popular', 'display_plugins_table' );
-add_action( 'install_plugins_recommended', 'display_plugins_table' );
-add_action( 'install_plugins_new', 'display_plugins_table' );
-add_action( 'install_plugins_beta', 'display_plugins_table' );
-add_action( 'install_plugins_favorites', 'display_plugins_table' );
 add_action( 'install_plugins_pre_plugin-information', 'install_plugin_information' );
 
 // Template hooks.

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -105,14 +105,8 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 			$tabs['search'] = __( 'Search Results' );
 		}
 
-		if ( 'beta' === $tab || false !== strpos( get_bloginfo( 'version' ), '-' ) ) {
-			$tabs['beta'] = _x( 'Beta Testing', 'Plugin Installer' );
-		}
-
-		$tabs['featured']    = _x( 'Featured', 'Plugin Installer' );
-		$tabs['popular']     = _x( 'Popular', 'Plugin Installer' );
-		$tabs['recommended'] = _x( 'Recommended', 'Plugin Installer' );
-		$tabs['favorites']   = _x( 'Favorites', 'Plugin Installer' );
+		$tabs['popular']    = _x( 'Popular', 'Plugin Installer' );
+		$tabs['categories'] = _x( 'Categories', 'Plugin Installer' );
 
 		if ( current_user_can( 'upload_plugins' ) ) {
 			// No longer a real tab. Here for filter compatibility.
@@ -128,7 +122,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		 * @since 2.7.0
 		 *
 		 * @param string[] $tabs The tabs shown on the Add Plugins screen. Defaults include
-		 *                       'featured', 'popular', 'recommended', 'favorites', and 'upload'.
+		 *                       'popular' and 'categories'.
 		 */
 		$tabs = apply_filters( 'install_plugins_tabs', $tabs );
 
@@ -174,37 +168,8 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 
 				break;
 
-			case 'featured':
 			case 'popular':
-			case 'new':
-			case 'beta':
 				$args['browse'] = $tab;
-				break;
-			case 'recommended':
-				$args['browse'] = $tab;
-				// Include the list of installed plugins so we can get relevant results.
-				$args['installed_plugins'] = array_keys( $installed_plugins );
-				break;
-
-			case 'favorites':
-				$action = 'save_wporg_username_' . get_current_user_id();
-				if ( isset( $_GET['_wpnonce'] ) && wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), $action ) ) {
-					$user = isset( $_GET['user'] ) ? wp_unslash( $_GET['user'] ) : get_user_option( 'wporg_favorites' );
-
-					// If the save url parameter is passed with a falsey value, don't save the favorite user.
-					if ( ! isset( $_GET['save'] ) || $_GET['save'] ) {
-						update_user_meta( get_current_user_id(), 'wporg_favorites', $user );
-					}
-				} else {
-					$user = get_user_option( 'wporg_favorites' );
-				}
-				if ( $user ) {
-					$args['user'] = $user;
-				} else {
-					$args = false;
-				}
-
-				add_action( 'install_plugins_favorites', 'install_plugins_favorites_form', 9, 0 );
 				break;
 
 			default:
@@ -219,13 +184,10 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		 *
 		 * Possible hook names include:
 		 *
-		 *  - `install_plugins_table_api_args_favorites`
-		 *  - `install_plugins_table_api_args_featured`
 		 *  - `install_plugins_table_api_args_popular`
-		 *  - `install_plugins_table_api_args_recommended`
+		 *  - `install_plugins_table_api_args_categories`
 		 *  - `install_plugins_table_api_args_upload`
 		 *  - `install_plugins_table_api_args_search`
-		 *  - `install_plugins_table_api_args_beta`
 		 *
 		 * @since 3.7.0
 		 *
@@ -288,11 +250,12 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 	/**
 	 */
 	public function no_items() {
+		global $tab;
 		if ( isset( $this->error ) ) { ?>
 			<div class="inline error"><p><?php echo $this->error->get_error_message(); ?></p>
 				<p class="hide-if-no-js"><button class="button try-again"><?php _e( 'Try Again' ); ?></button></p>
 			</div>
-		<?php } else { ?>
+		<?php } elseif ( $tab !== 'categories' ) { ?>
 			<div class="no-plugin-results"><?php _e( 'No plugins found. Try a different search.' ); ?></div>
 			<?php
 		}

--- a/src/wp-admin/js/plugin-install.js
+++ b/src/wp-admin/js/plugin-install.js
@@ -226,4 +226,12 @@ jQuery( function( $ ) {
 				$uploadViewToggle.attr( 'aria-expanded', $body.hasClass( 'show-upload-view' ) );
 			});
 	}
+
+	/* Plugin install Category filter JS */
+	$( '.plugin-categories-filter a' ).click( function( event ) {
+		event.preventDefault();
+		var category = $(this).attr( 'data-plugin-tag' );
+		$( '#typeselector' ).val( 'tag' );
+		$( '.plugin-install-php .wp-filter-search' ).val( category ).trigger( 'input' );
+	});
 });

--- a/src/wp-admin/js/plugin-install.js
+++ b/src/wp-admin/js/plugin-install.js
@@ -228,7 +228,7 @@ jQuery( function( $ ) {
 	}
 
 	/* Plugin install Category filter JS */
-	$( '.plugin-categories-filter a' ).click( function( event ) {
+	$( '.plugin-categories-filter a' ).on( 'click', function( event ) {
 		event.preventDefault();
 		var category = $(this).attr( 'data-plugin-tag' );
 		$( '#typeselector' ).val( 'tag' );

--- a/src/wp-admin/js/updates.js
+++ b/src/wp-admin/js/updates.js
@@ -2557,10 +2557,11 @@
 
 			if ( wp.updates.searchTerm === data.s && 'typechange' !== eventtype ) {
 				return;
-			} else {
-				$pluginFilter.empty();
-				wp.updates.searchTerm = data.s;
 			}
+
+			$pluginFilter.empty();
+			$( '.plugin-categories-filter-container' ).remove();
+			wp.updates.searchTerm = data.s;
 
 			if ( window.history && window.history.replaceState ) {
 				window.history.replaceState( null, '', searchLocation );


### PR DESCRIPTION
## Description
Fixes #91, manual backport of changes made in V1.
From this commit:
https://github.com/ClassicPress/ClassicPress/commit/39f10b0ee215db6fe9a402a5eed231de8cc3ca9a

The changes in `src/wp-admin/includes/plugin-install.php` remained in the `v2` code.

## Motivation and context
Removes features from plugin page that are more applicable in WordPress.

## How has this been tested?
Local testing only.

## Screenshots
<img width="1562" alt="Screenshot 2023-05-29 at 11 15 59" src="https://github.com/ClassicPress/ClassicPress-v2/assets/1280733/caaf82fe-564d-496a-b771-9a7514361706">
<img width="1560" alt="Screenshot 2023-05-29 at 11 16 36" src="https://github.com/ClassicPress/ClassicPress-v2/assets/1280733/7514dbb4-66fc-4efa-82ef-2449314a5fb2">

## Types of changes
- Enhancement
