### PR TITLE
Mark FSE themes as not installable

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3554,7 +3554,7 @@ function wp_ajax_query_themes() {
 
 	/** This filter is documented in wp-admin/includes/class-wp-theme-install-list-table.php */
 	$args = apply_filters( 'install_themes_table_api_args_' . $old_filter, $args );
-	$args['fields']['tags']=true;
+	$args['fields']['tags'] = true;
 
 	$api = themes_api( 'query_themes', $args );
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3554,6 +3554,7 @@ function wp_ajax_query_themes() {
 
 	/** This filter is documented in wp-admin/includes/class-wp-theme-install-list-table.php */
 	$args = apply_filters( 'install_themes_table_api_args_' . $old_filter, $args );
+	$args['fields']['tags']=true;
 
 	$api = themes_api( 'query_themes', $args );
 
@@ -3639,6 +3640,7 @@ function wp_ajax_query_themes() {
 		$theme->preview_url    = set_url_scheme( $theme->preview_url );
 		$theme->compatible_wp  = is_wp_version_compatible( $theme->requires );
 		$theme->compatible_php = is_php_version_compatible( $theme->requires_php );
+		$theme->compatible_cp  = ! array_key_exists( 'full-site-editing', $theme->tags );
 	}
 
 	wp_send_json_success( $api );

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -1028,18 +1028,18 @@ function customize_themes_print_templates() {
 							/* translators: %s: Theme name. */
 							$aria_label = sprintf( _x( 'Activate %s', 'theme' ), '{{ data.name }}' );
 						?>
-						<# if ( data.compatibleWP && data.compatiblePHP && data.actions.activate ) { #>
+						<# if ( data.compatibleWP && data.compatiblePHP && data.actions.activate && data.compatibleCP !== false ) { #>
 							<a href="{{{ data.actions.activate }}}" class="button button-primary activate" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Activate' ); ?></a>
 						<# } #>
 					<# } else { #>
-						<# if ( data.compatibleWP && data.compatiblePHP ) { #>
+						<# if ( data.compatibleWP && data.compatiblePHP && data.compatibleCP !== false ) { #>
 							<button type="button" class="button button-primary preview-theme" data-slug="{{ data.id }}"><?php _e( 'Live Preview' ); ?></button>
 						<# } else { #>
 							<button class="button button-primary disabled"><?php _e( 'Live Preview' ); ?></button>
 						<# } #>
 					<# } #>
 				<# } else { #>
-					<# if ( data.compatibleWP && data.compatiblePHP ) { #>
+					<# if ( data.compatibleWP && data.compatiblePHP && data.compatibleCP !== false ) { #>
 						<button type="button" class="button theme-install" data-slug="{{ data.id }}"><?php _e( 'Install' ); ?></button>
 						<button type="button" class="button button-primary theme-install preview" data-slug="{{ data.id }}"><?php _e( 'Install &amp; Preview' ); ?></button>
 					<# } else { #>

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -327,7 +327,7 @@ if ( $tab ) {
 				?>
 			<# } else if ( ! data.compatible_cp ) { #>
 				<?php
-				_e( 'FSE themes don\'t work with ClassicPress.' );
+				_e( "FSE themes don't work with ClassicPress." );
 				?>
 			<# } else if ( ! data.compatible_php ) { #>
 				<?php
@@ -532,7 +532,7 @@ if ( $tab ) {
 									?>
 								<# } else if ( ! data.compatible_cp ) { #>
 									<?php
-									_e( 'FSE themes don\'t work with ClassicPress.' );
+									_e( "FSE themes don't work with ClassicPress." );
 									?>
 								<# } else if ( ! data.compatible_php ) { #>
 									<?php

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -434,7 +434,7 @@ if ( $tab ) {
 				?>
 			</span></button>
 			<# if ( data.installed ) { #>
-				<# if ( data.compatible_wp && data.compatible_php ) { #>
+				<# if ( data.compatible_wp && data.compatible_php && data.compatible_cp ) { #>
 					<?php
 					/* translators: %s: Theme name. */
 					$aria_label = sprintf( _x( 'Activate %s', 'theme' ), '{{ data.name }}' );
@@ -448,7 +448,7 @@ if ( $tab ) {
 					<a class="button button-primary disabled" ><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
 				<# } #>
 			<# } else { #>
-				<# if ( data.compatible_wp && data.compatible_php ) { #>
+				<# if ( data.compatible_wp && data.compatible_php && data.compatible_cp ) { #>
 					<a href="{{ data.install_url }}" class="button button-primary theme-install" data-name="{{ data.name }}" data-slug="{{ data.id }}"><?php _e( 'Install' ); ?></a>
 				<# } else { #>
 					<a class="button button-primary disabled" ><?php _ex( 'Cannot Install', 'theme' ); ?></a>
@@ -491,7 +491,7 @@ if ( $tab ) {
 							?>
 						</div>
 
-						<# if ( ! data.compatible_wp || ! data.compatible_php ) { #>
+						<# if ( ! data.compatible_wp || ! data.compatible_php || ! data.compatible_cp ) { #>
 							<div class="notice notice-error notice-alt notice-large"><p>
 								<# if ( ! data.compatible_wp && ! data.compatible_php ) { #>
 									<?php
@@ -529,6 +529,10 @@ if ( $tab ) {
 											self_admin_url( 'update-core.php' )
 										);
 									}
+									?>
+								<# } else if ( ! data.compatible_cp ) { #>
+									<?php
+									_e( 'Full site editing themes can\'t work with ClassicPress.' );
 									?>
 								<# } else if ( ! data.compatible_php ) { #>
 									<?php

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -286,7 +286,7 @@ if ( $tab ) {
 		<div class="notice notice-success notice-alt"><p><?php _ex( 'Installed', 'theme' ); ?></p></div>
 	<# } #>
 
-	<# if ( ! data.compatible_wp || ! data.compatible_php ) { #>
+	<# if ( ! data.compatible_wp || ! data.compatible_php || ! data.compatible_cp ) { #>
 		<div class="notice notice-error notice-alt"><p>
 			<# if ( ! data.compatible_wp && ! data.compatible_php ) { #>
 				<?php
@@ -325,6 +325,10 @@ if ( $tab ) {
 					);
 				}
 				?>
+			<# } else if ( ! data.compatible_cp ) { #>
+				<?php
+				_e( 'Full site editing themes can\'t work with ClassicPress.' );
+				?>
 			<# } else if ( ! data.compatible_php ) { #>
 				<?php
 				_e( 'This theme does not work with your version of PHP.' );
@@ -354,7 +358,7 @@ if ( $tab ) {
 
 		<div class="theme-actions">
 			<# if ( data.installed ) { #>
-				<# if ( data.compatible_wp && data.compatible_php ) { #>
+				<# if ( data.compatible_wp && data.compatible_php && data.compatible_cp ) { #>
 					<?php
 					/* translators: %s: Theme name. */
 					$aria_label = sprintf( _x( 'Activate %s', 'theme' ), '{{ data.name }}' );
@@ -388,7 +392,7 @@ if ( $tab ) {
 					<# } #>
 				<# } #>
 			<# } else { #>
-				<# if ( data.compatible_wp && data.compatible_php ) { #>
+				<# if ( data.compatible_wp && data.compatible_php && data.compatible_cp ) { #>
 					<?php
 					/* translators: %s: Theme name. */
 					$aria_label = sprintf( _x( 'Install %s', 'theme' ), '{{ data.name }}' );

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -327,7 +327,7 @@ if ( $tab ) {
 				?>
 			<# } else if ( ! data.compatible_cp ) { #>
 				<?php
-				_e( 'Full site editing themes can\'t work with ClassicPress.' );
+				_e( 'FSE themes don\'t work with ClassicPress.' );
 				?>
 			<# } else if ( ! data.compatible_php ) { #>
 				<?php
@@ -532,7 +532,7 @@ if ( $tab ) {
 									?>
 								<# } else if ( ! data.compatible_cp ) { #>
 									<?php
-									_e( 'Full site editing themes can\'t work with ClassicPress.' );
+									_e( 'FSE themes don\'t work with ClassicPress.' );
 									?>
 								<# } else if ( ! data.compatible_php ) { #>
 									<?php

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -5872,6 +5872,8 @@ final class WP_Customize_Manager {
 				$args['browse'] = 'new'; // Sort by latest themes by default.
 			}
 
+			$args['fields']['tags']=true;
+
 			// Load themes from the .org API.
 			$themes = themes_api( 'query_themes', $args );
 			if ( is_wp_error( $themes ) ) {
@@ -5936,6 +5938,7 @@ final class WP_Customize_Manager {
 				$theme->authorAndUri  = wp_kses( $theme->author['display_name'], $themes_allowedtags );
 				$theme->compatibleWP  = is_wp_version_compatible( $theme->requires ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName
 				$theme->compatiblePHP = is_php_version_compatible( $theme->requires_php ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName
+				$theme->compatibleCP  = ! array_key_exists( 'full-site-editing', $theme->tags );
 
 				if ( isset( $theme->parent ) ) {
 					$theme->parent = $theme->parent['slug'];

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -5872,7 +5872,7 @@ final class WP_Customize_Manager {
 				$args['browse'] = 'new'; // Sort by latest themes by default.
 			}
 
-			$args['fields']['tags']=true;
+			$args['fields']['tags'] = true;
 
 			// Load themes from the .org API.
 			$themes = themes_api( 'query_themes', $args );

--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -176,7 +176,7 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 				<# } #>
 			<# } #>
 
-			<# if ( ! data.theme.compatibleWP || ! data.theme.compatiblePHP ) { #>
+			<# if ( ! data.theme.compatibleWP || ! data.theme.compatiblePHP || data.theme.compatibleCP === false ) { #>
 				<div class="notice notice-error notice-alt"><p>
 					<# if ( ! data.theme.compatibleWP && ! data.theme.compatiblePHP ) { #>
 						<?php
@@ -214,6 +214,10 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 								self_admin_url( 'update-core.php' )
 							);
 						}
+						?>
+					<# } else if ( data.theme.compatibleCP === false ) { #>
+						<?php
+						_e( 'Full site editing themes can\'t work with ClassicPress.' );
 						?>
 					<# } else if ( ! data.theme.compatiblePHP ) { #>
 						<?php
@@ -274,7 +278,7 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 					<div class="theme-id-container">
 						<h3 class="theme-name" id="{{ data.section }}-{{ data.theme.id }}-name">{{ data.theme.name }}</h3>
 						<div class="theme-actions">
-							<# if ( data.theme.compatibleWP && data.theme.compatiblePHP ) { #>
+							<# if ( data.theme.compatibleWP && data.theme.compatiblePHP && data.theme.compatibleCP !== false ) { #>
 								<button type="button" class="button button-primary preview-theme" aria-label="<?php echo esc_attr( $preview_label ); ?>" data-slug="{{ data.theme.id }}"><?php _e( 'Live Preview' ); ?></button>
 							<# } else { #>
 								<button type="button" class="button button-primary disabled" aria-label="<?php echo esc_attr( $preview_label ); ?>"><?php _e( 'Live Preview' ); ?></button>
@@ -287,7 +291,7 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 				<div class="theme-id-container">
 					<h3 class="theme-name" id="{{ data.section }}-{{ data.theme.id }}-name">{{ data.theme.name }}</h3>
 					<div class="theme-actions">
-						<# if ( data.theme.compatibleWP && data.theme.compatiblePHP ) { #>
+						<# if ( data.theme.compatibleWP && data.theme.compatiblePHP && data.theme.compatibleCP !== false ) { #>
 							<button type="button" class="button button-primary theme-install preview" aria-label="<?php echo esc_attr( $install_label ); ?>" data-slug="{{ data.theme.id }}" data-name="{{ data.theme.name }}"><?php _e( 'Install &amp; Preview' ); ?></button>
 						<# } else { #>
 							<button type="button" class="button button-primary disabled" aria-label="<?php echo esc_attr( $install_label ); ?>" disabled><?php _e( 'Install &amp; Preview' ); ?></button>

--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -217,7 +217,7 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 						?>
 					<# } else if ( data.theme.compatibleCP === false ) { #>
 						<?php
-						_e( 'Full site editing themes can\'t work with ClassicPress.' );
+						_e( 'FSE themes don\'t work with ClassicPress.' );
 						?>
 					<# } else if ( ! data.theme.compatiblePHP ) { #>
 						<?php

--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -217,7 +217,7 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 						?>
 					<# } else if ( data.theme.compatibleCP === false ) { #>
 						<?php
-						_e( 'FSE themes don\'t work with ClassicPress.' );
+						_e( "FSE themes don't work with ClassicPress." );
 						?>
 					<# } else if ( ! data.theme.compatiblePHP ) { #>
 						<?php


### PR DESCRIPTION
As now FSE themes can be installed and activated, producing critical errors.

## Description
With this PR FSE themes from WP directory are marked and made uninstallable.
Closes #65.

## How has this been tested?
Local testing.

## Screenshots

### After
<img width="815" alt="image" src="https://github.com/ClassicPress/ClassicPress-v2/assets/29772709/4c911c60-7f6e-444d-945e-e0f1609603d6">
<img width="912" alt="image" src="https://github.com/ClassicPress/ClassicPress-v2/assets/29772709/b4b133ab-83e2-4d7e-8507-9348c5eccddb">
<img width="291" alt="image" src="https://github.com/ClassicPress/ClassicPress-v2/assets/29772709/78ea29a6-d18f-4133-b21e-802c481b8cb5">


## Types of changes
- New feature

