### PR TITLE
Fix menu icons for Multisite adminbar

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -589,9 +589,17 @@ function wp_admin_bar_my_sites_menu( $wp_admin_bar ) {
 	foreach ( (array) $wp_admin_bar->user->blogs as $blog ) {
 		switch_to_blog( $blog->userblog_id );
 
-		$cp_logo_src = includes_url( 'images/classicpress-logo-dashicon-grey-on-transparent.svg' );
-
-		$cplogo = '<img class="cp-logo" src="' . $cp_logo_src . '" alt="" />';
+		if ( true === $show_site_icons && has_site_icon() ) {
+			$cplogo = sprintf(
+				'<img class="blavatar" src="%s" srcset="%s 2x" alt="" width="16" height="16"%s />',
+				esc_url( get_site_icon_url( 16 ) ),
+				esc_url( get_site_icon_url( 32 ) ),
+				( wp_lazy_loading_enabled( 'img', 'site_icon_in_toolbar' ) ? ' loading="lazy"' : '' )
+			);
+		} else {
+			$cp_logo_src = includes_url( 'images/classicpress-logo-dashicon-grey-on-transparent.svg' );
+			$cplogo      = '<img class="blavatar" src="' . $cp_logo_src . '" alt="" />';
+		}
 
 		$blogname = $blog->blogname;
 

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -597,8 +597,11 @@ function wp_admin_bar_my_sites_menu( $wp_admin_bar ) {
 				( wp_lazy_loading_enabled( 'img', 'site_icon_in_toolbar' ) ? ' loading="lazy"' : '' )
 			);
 		} else {
-			$cp_logo_src = includes_url( 'images/classicpress-logo-dashicon-grey-on-transparent.svg' );
-			$cplogo      = '<img class="blavatar" src="' . $cp_logo_src . '" alt="" />';
+			$cplogo = sprintf(
+				'<img class="blavatar" src="%s" alt=""%s />',
+				esc_url( includes_url( 'images/classicpress-logo-dashicon-grey-on-transparent.svg' ) ),
+				( wp_lazy_loading_enabled( 'img', 'site_icon_in_toolbar' ) ? ' loading="lazy"' : '' )
+			);
 		}
 
 		$blogname = $blog->blogname;


### PR DESCRIPTION
## Description
Potential fix for #85.

## Motivation and context
The original creation of v2 from WordPress 6.2 removed things like Gravatar, the icons in the Multisite menu use a class of `blavatar` and the code was were inadvertently removed. This restores the code and updates the default upstream icon for ClassicPress

## How has this been tested?
Local testing, screen grabs included

## Screenshots
### Before
See #85

### After
<img width="343" alt="Screenshot 2023-06-03 at 19 47 56" src="https://github.com/ClassicPress/ClassicPress-v2/assets/1280733/fe480be5-5715-41d5-85d4-b2223cf61b66">

One other option is to drop the icon completely like this:

<img width="344" alt="Screenshot 2023-06-03 at 18 22 30" src="https://github.com/ClassicPress/ClassicPress-v2/assets/1280733/356486f8-0de5-4ed3-8228-f5b44cbc7b08">

## Types of changes
- Bug fix
