### PR TITLE
Remove `is_block_theme` check

### DIFF
--- a/src/wp-admin/includes/class-theme-installer-skin.php
+++ b/src/wp-admin/includes/class-theme-installer-skin.php
@@ -115,7 +115,7 @@ class Theme_Installer_Skin extends WP_Upgrader_Skin {
 
 		$install_actions = array();
 
-		if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) && ! $theme_info->is_block_theme() ) {
+		if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) ) {
 			$customize_url = add_query_arg(
 				array(
 					'theme'  => urlencode( $stylesheet ),


### PR DESCRIPTION
Upgrading a theme triggers an error for `is_block_theme()` method missing from class `WP_Theme`.

## Description
Remove the check in the `if` statement.

## How has this been tested?
Local installation.

## Screenshots
<!--
Screenshots are very helpful for reviewers to quickly see how your change works.
-->

### Before
<img width="667" alt="image" src="https://github.com/ClassicPress/ClassicPress-v2/assets/29772709/3c5e5d22-e8b2-4d36-9909-851c9ba08150">

### After
<img width="554" alt="image" src="https://github.com/ClassicPress/ClassicPress-v2/assets/29772709/e70b1a50-afe3-40c9-8eb2-b4d4d6b3966f">

## Types of changes
- Bug fix