### PR TITLE
fix: removed wp_credits() function

### DIFF
--- a/src/wp-admin/credits.php
+++ b/src/wp-admin/credits.php
@@ -16,7 +16,6 @@ list( $display_version ) = explode( '-', get_bloginfo( 'version' ) );
 
 require_once ABSPATH . 'wp-admin/admin-header.php';
 
-$credits = wp_credits();
 ?>
 <div class="wrap about-wrap full-width-layout">
 


### PR DESCRIPTION
## Description
The function was removed. It's not needed.

## Motivation and context
It throws an error trying to visit "Credits" tab on About page. It's not used in CP.

## How has this been tested?
Locally.

## Types of changes
Bug fix
