### PR TITLE
Fix `WP_Compat` to work with `WP-CLI` 

### DIFF
--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -433,8 +433,7 @@ final class WP_Screen {
 	 * @return bool False.
 	 */
 	public function is_block_editor( ...$args ) {
-		global $wp_compat;
-		$wp_compat->using_block_function();
+		WP_Compat::using_block_function();
 		return false;
 	}
 

--- a/src/wp-includes/classicpress/class-wp-block-type.php
+++ b/src/wp-includes/classicpress/class-wp-block-type.php
@@ -17,37 +17,31 @@
 
 class WP_Block_Type {
 	public function __set( $name, $value ) {
-		global $wp_compat;
-		$wp_compat->using_block_function();
+		WP_Compat::using_block_function();
 	}
 
 	public function __get( $name ) {
-		global $wp_compat;
-		$wp_compat->using_block_function();
+		WP_Compat::using_block_function();
 		return false;
 	}
 
 	public function __isset( $name ) {
-		global $wp_compat;
-		$wp_compat->using_block_function();
+		WP_Compat::using_block_function();
 		return false;
 	}
 
 	public function __unset( $name ) {
-		global $wp_compat;
-		$wp_compat->using_block_function();
+		WP_Compat::using_block_function();
 		return false;
 	}
 
 	public function __call( $name, $arguments ) {
-		global $wp_compat;
-		$wp_compat::using_block_function();
+		WP_Compat::using_block_function();
 		return false;
 	}
 
 	public static function __callstatic( $name, $arguments ) {
-		global $wp_compat;
-		$wp_compat::using_block_function();
+		WP_Compat::using_block_function();
 		return false;
 	}
 }

--- a/src/wp-includes/classicpress/class-wp-compat.php
+++ b/src/wp-includes/classicpress/class-wp-compat.php
@@ -8,23 +8,23 @@
 
 class WP_Compat {
 
-	public $blocks_compatibility_level = null;
+	public static $blocks_compatibility_level = null;
 
 	public function __construct() {
 
-		if ( null === $this->blocks_compatibility_level ) {
-			$this->blocks_compatibility_level = (int) get_option( 'blocks_compatibility_level', 1 );
+		if ( null === self::$blocks_compatibility_level ) {
+			self::$blocks_compatibility_level = (int) get_option( 'blocks_compatibility_level', 1 );
 		}
 
 		add_action( 'update_option_blocks_compatibility_level', array( $this, 'purge_options' ), 10, 2 );
 
-		if ( 0 === $this->blocks_compatibility_level ) {
+		if ( 0 === self::$blocks_compatibility_level ) {
 			return;
 		}
 
 		$this->define_polyfills();
 
-		if ( 1 === $this->blocks_compatibility_level ) {
+		if ( 1 === self::$blocks_compatibility_level ) {
 			return;
 		}
 
@@ -173,7 +173,7 @@ class WP_Compat {
 	 * @param string $path
 	 * @return string
 	 */
-	private function plugin_folder( $path ) {
+	private static function plugin_folder( $path ) {
 		return preg_replace( '~^' . preg_quote( WP_PLUGIN_DIR ) . preg_quote( DIRECTORY_SEPARATOR ) . '([^' . preg_quote( DIRECTORY_SEPARATOR ) . ']*).*~', '$1', $path );
 	}
 
@@ -194,8 +194,8 @@ class WP_Compat {
 	 *
 	 * @return void
 	 */
-	public function using_block_function() {
-		if ( 2 !== $this->blocks_compatibility_level ) {
+	public static function using_block_function() {
+		if ( 2 !== self::$blocks_compatibility_level ) {
 			return;
 		}
 
@@ -221,14 +221,14 @@ class WP_Compat {
 			$traces = array_column( $trace, 'file' );
 			$traces = array_map(
 				function( $path ) {
-					return $this->plugin_folder( $path );
+					return self::plugin_folder( $path );
 				},
 				$traces
 			);
 			$active = wp_get_active_and_valid_plugins();
 			$active = array_map(
 				function( $path ) {
-					return $this->plugin_folder( $path );
+					return self::plugin_folder( $path );
 				},
 				$active
 			);
@@ -263,8 +263,7 @@ class WP_Compat {
 			 * @return bool False.
 			 */
 			function register_block_type( ...$args ) {
-				global $wp_compat;
-				$wp_compat->using_block_function();
+				WP_Compat::using_block_function();
 				return false;
 			}
 		}
@@ -278,8 +277,7 @@ class WP_Compat {
 			 * @return bool False.
 			 */
 			function register_block_type_from_metadata( ...$args ) {
-				global $wp_compat;
-				$wp_compat->using_block_function();
+				WP_Compat::using_block_function();
 				return false;
 			}
 		}
@@ -293,8 +291,7 @@ class WP_Compat {
 			 * @return bool False.
 			 */
 			function has_block( ...$args ) {
-				global $wp_compat;
-				$wp_compat->using_block_function();
+				WP_Compat::using_block_function();
 				return false;
 			}
 		}
@@ -308,8 +305,7 @@ class WP_Compat {
 			 * @return bool False.
 			 */
 			function has_blocks( ...$args ) {
-				global $wp_compat;
-				$wp_compat->using_block_function();
+				WP_Compat::using_block_function();
 				return false;
 			}
 		}
@@ -323,8 +319,7 @@ class WP_Compat {
 			 * @return bool False.
 			 */
 			function register_block_pattern( ...$args ) {
-				global $wp_compat;
-				$wp_compat->using_block_function();
+				WP_Compat::using_block_function();
 				return false;
 			}
 		}

--- a/tests/phpunit/tests/compat/wordpress.php
+++ b/tests/phpunit/tests/compat/wordpress.php
@@ -10,16 +10,12 @@ class Tests_Compat_wordpress extends WP_UnitTestCase {
 	public static function wpSetUpBeforeClass() {
 		// Use 'Troubleshooting' mode for deeper testing
 		update_option( 'blocks_compatibility_level', '2' );
-
-		global $wp_compat;
-		$wp_compat->blocks_compatibility_level = 2;
+		WP_Compat::$blocks_compatibility_level = 2;
 	}
 
 	public static function wpTearDownAfterClass() {
 		update_option( 'blocks_compatibility_level', '1' );
-
-		global $wp_compat;
-		$wp_compat->blocks_compatibility_level = 1;
+		WP_Compat::$blocks_compatibility_level = 1;
 	}
 
 	/**
@@ -28,9 +24,7 @@ class Tests_Compat_wordpress extends WP_UnitTestCase {
 	public function test_default_blocks_compatibility_level() {
 		$option = get_option( 'blocks_compatibility_level' );
 		$this->assertSame( $option, '2' );
-
-		global $wp_compat;
-		$this->assertSame( $wp_compat->blocks_compatibility_level, 2 );
+		$this->assertSame( WP_Compat::$blocks_compatibility_level, 2 );
 	}
 
 	/**


### PR DESCRIPTION
As reported by @viktorix 
![image](https://github.com/ClassicPress/ClassicPress-v2/assets/29772709/0738d8fb-88b2-4937-8dfa-a593092cb265)
`WP-CLI` throws an error when block functions are called.

## Description
The polyfills rely on the global `$wp_compat`. But `WP-CLI` loads ClassicPress inside a functions, so not all variables are accessible as global.
This PR calls `WP_Compat::using_block_function()`, so there is no need to use the global.

## How has this been tested?
Local installation.

## Types of changes
- Bug fix
