### PR TITLE
Fix version check in Site Health

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -251,7 +251,7 @@ class WP_Site_Health {
 	 *
 	 * @return array The test result.
 	 */
-	public function get_test_wordpress_version() {
+	public function get_test_classicpress_version() {
 		$result = array(
 			'label'       => '',
 			'status'      => '',
@@ -261,7 +261,7 @@ class WP_Site_Health {
 			),
 			'description' => '',
 			'actions'     => '',
-			'test'        => 'wordpress_version',
+			'test'        => 'classicpress_version',
 		);
 
 		$core_current_version = get_bloginfo( 'version' );


### PR DESCRIPTION
## Description
I'm seeing entries in `error_log` files linked to the cron Site Health tests, I think this will only impact PHP 8.0 and above.

It is created by a set of conditions as follows:

The `src` code still [contains](https://github.com/ClassicPress/ClassicPress-v2/blob/d3376f7223f69e3eaff67a491c0ae6852b566350/src/wp-admin/includes/class-wp-site-health.php#L254) a function called `get_test_wordpress_version()`.
The `get_tests()` function however has been updated to [return](https://github.com/ClassicPress/ClassicPress-v2/blob/d3376f7223f69e3eaff67a491c0ae6852b566350/src/wp-admin/includes/class-wp-site-health.php#L2483) a `classicpress_version` test name.
The `wp_cron_scheduled_check()` function loops through these test names and tries to find a function called `get_test_%s' where %s is the passed test name. For `get_test_classicpress_version` this fails so the fall back is to drop the `get_test_` prefix, that results in the test simply returning the ClassicPress version number.
This finally result in the logging of a 'TypeError: Cannot access offset of type string on string' error as the result is expected to be an array not the version number as a string.

## Motivation and context
We need to avoid this error and ensure we don't create `error_log` file entries.

## How has this been tested?
Local testing.

## Screenshots
N/A
## Types of changes
- Bug fix