### PR TITLE
Fully enable PHP 8.1 testing

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.0', '7.4' ]
+        php: [ '8.1', '8.0', '7.4' ]
         mysql: [ '5.7' ]
         memcached: [ false ]
         experimental: [ false ]
@@ -48,10 +48,6 @@ jobs:
             mysql: '5.7'
             memcached: true
             experimental: false
-          - php: '8.1'
-            mysql: '5.7'
-            memcached: false
-            experimental: true
           - php: '8.2'
             mysql: '5.7'
             memcached: false


### PR DESCRIPTION
## Description
PHP 8.1 testing is currently considered Experimental and is allowed to fail without impacting PR merging. 

## Motivation and context
The tests are all passing cleanly and PHP 8.0 is due to be "end of life" later this year. We should ensure 8.1 is not considered experimental now.

## How has this been tested?
Will be in the GH Action testing

## Screenshots
N/A

## Types of changes
- Enhancement
