### PR TITLE
Use ClassicPress instead of WordPress when sending mail

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -360,7 +360,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 
 		// If we don't have a name from the input headers.
 		if ( ! isset( $from_name ) ) {
-			$from_name = 'WordPress';
+			$from_name = 'ClassicPress';
 		}
 
 		/*
@@ -373,7 +373,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		if ( ! isset( $from_email ) ) {
 			// Get the site domain and get rid of www.
 			$sitename   = wp_parse_url( network_home_url(), PHP_URL_HOST );
-			$from_email = 'wordpress@';
+			$from_email = 'classicpress@';
 
 			if ( null !== $sitename ) {
 				if ( 'www.' === substr( $sitename, 0, 4 ) ) {

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -231,7 +231,7 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 		$subject  = 'Testing';
 		$message  = 'Test Message';
 		$headers  = 'From: ';
-		$expected = 'From: WordPress <wordpress@' . WP_TESTS_DOMAIN . '>';
+		$expected = 'From: ClassicPress <classicpress@' . WP_TESTS_DOMAIN . '>';
 
 		wp_mail( $to, $subject, $message, $headers );
 
@@ -246,8 +246,8 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 		$to       = 'address@tld.com';
 		$subject  = 'Testing';
 		$message  = 'Test Message';
-		$headers  = 'From: <wordpress@example.com>';
-		$expected = 'From: WordPress <wordpress@example.com>';
+		$headers  = 'From: <classicpress@example.com>';
+		$expected = 'From: ClassicPress <classicpress@example.com>';
 
 		wp_mail( $to, $subject, $message, $headers );
 


### PR DESCRIPTION
## Description
`wp_mail` fallback is `From: WordPress <wordpress@site.com>` when the sender is not set.
This PR changes `WordPress <wordpress@site.com>` to `ClassicPress <classicpress@site.com>`.

## Motivation and context
Can be confusing for an user to get mail from WordPress when they have installed ClassicPress.
ClassicPress v1 uses ClassicPress, so after upgrading to v2 it's a better UX to have the same sender.

## How has this been tested?
Unit tests were already in place.
