### PR TITLE
Fix nav menu PHP notices

### DIFF
--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -177,9 +177,10 @@ class Walker_Nav_Menu extends Walker {
 		$atts           = array();
 		$atts['title']  = ! empty( $menu_item->attr_title ) ? $menu_item->attr_title : '';
 		$atts['target'] = ! empty( $menu_item->target ) ? $menu_item->target : '';
-		if ( '_blank' === $menu_item->target && empty( $menu_item->xfn ) ) {
+
+		if ( ! empty( $menu_item->target ) && '_blank' === $menu_item->target ) {
 			$atts['rel'] = 'noopener';
-		} else {
+		} elseif ( ! empty( $menu_item->xfn ) ) {
 			$atts['rel'] = $menu_item->xfn;
 		}
 
@@ -193,7 +194,7 @@ class Walker_Nav_Menu extends Walker {
 			$atts['href'] = '';
 		}
 
-		$atts['aria-current'] = $menu_item->current ? 'page' : '';
+		$atts['aria-current'] = ! empty( $menu_item->current ) ? 'page' : '';
 
 		/**
 		 * Filters the HTML attributes applied to a menu item's anchor element.

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -186,7 +186,11 @@ class Walker_Nav_Menu extends Walker {
 
 		if ( ! empty( $menu_item->url ) ) {
 			if ( get_privacy_policy_url() === $menu_item->url ) {
-				$atts['rel'] = empty( $atts['rel'] ) ? 'privacy-policy' : $atts['rel'] . ' privacy-policy';
+				if ( ! empty( $menu_item->target && '_blank' === $menu_item->target && ! empty( $menu_item->xfn ) ) ) {
+					$atts['rel'] = 'nofollow privacy-policy';
+				} else {
+					$atts['rel'] = empty( $atts['rel'] ) ? 'privacy-policy' : $atts['rel'] . ' privacy-policy';
+				}
 			}
 
 			$atts['href'] = $menu_item->url;

--- a/src/wp-includes/nav-menu-template.php
+++ b/src/wp-includes/nav-menu-template.php
@@ -187,7 +187,7 @@ function wp_nav_menu( $args = array() ) {
 			$show_container = true;
 			$class          = $args->container_class ? ' class="' . esc_attr( $args->container_class ) . '"' : ' class="menu-' . $menu->slug . '-container"';
 			$id             = $args->container_id ? ' id="' . esc_attr( $args->container_id ) . '"' : '';
-			$aria_label     = ( 'nav' === $args->container && $args->container_aria_label ) ? ' aria-label="' . esc_attr( $args->container_aria_label ) . '"' : '';
+			$aria_label     = ( 'nav' === $args->container && ! empty( $args->container_aria_label ) ) ? ' aria-label="' . esc_attr( $args->container_aria_label ) . '"' : '';
 			$nav_menu      .= '<' . $args->container . $id . $class . $aria_label . '>';
 		}
 	}


### PR DESCRIPTION
## Description
The PR aims to provide fixes for the issues reported in #122 

## Motivation and context
PHP warning / notices are being seen due to undefined properties, fixing this creates a better user experience when notices are displayed and reduces log sizes when these things are logged instead of displayed.

## How has this been tested?
Branch has been briefly tested by the OP, local code tests are passing (`phpcs` and `phpunit`) after a corrective action for 1 failing test.
GH Actions will also run on this PR.

## Screenshots
N/A

## Types of changes
- Bug fix
