### PR TITLE
Add new polyfills for LearnPress

### DIFF
--- a/src/wp-includes/classicpress/class-wp-block-template.php
+++ b/src/wp-includes/classicpress/class-wp-block-template.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Blocks API: WP_Block_Template class
+ *
+ * @package ClassicPress
+ * @subpackage Blocks
+ * @since CP-2.0.0
+ */
+
+/**
+ * Class representing a block template.
+ *
+ * @since CP-2.0.0
+ */
+#[AllowDynamicProperties]
+class WP_Block_Template {
+	public function __set( $name, $value ) {
+		WP_Compat::using_block_function();
+	}
+
+	public function __get( $name ) {
+		WP_Compat::using_block_function();
+		return false;
+	}
+
+	public function __isset( $name ) {
+		WP_Compat::using_block_function();
+		return false;
+	}
+
+	public function __unset( $name ) {
+		WP_Compat::using_block_function();
+		return false;
+	}
+
+	public function __call( $name, $arguments ) {
+		WP_Compat::using_block_function();
+		return false;
+	}
+
+	public static function __callstatic( $name, $arguments ) {
+		WP_Compat::using_block_function();
+		return false;
+	}
+}

--- a/src/wp-includes/classicpress/class-wp-compat.php
+++ b/src/wp-includes/classicpress/class-wp-compat.php
@@ -324,8 +324,23 @@ class WP_Compat {
 			}
 		}
 
+		if ( ! function_exists( 'wp_is_block_theme' ) ) {
+			/**
+			 * Polyfill for block functions.
+			 *
+			 * @since CP-2.0.0
+			 *
+			 * @return bool False.
+			 */
+			function wp_is_block_theme( ...$args ) {
+				WP_Compat::using_block_function();
+				return false;
+			}
+		}
+
 		// Load WP_Block_Type class file as polyfill.
 		require_once ABSPATH . WPINC . '/classicpress/class-wp-block-type.php';
+		require_once ABSPATH . WPINC . '/classicpress/class-wp-block-template.php';
 
 	}
 


### PR DESCRIPTION
As [reported on the forum](https://forums.classicpress.net/t/classicpress-v2-and-learnpress/4846), LearnPress plugin is not working because it is calling block-related functions.

This PR adds the necessary polyfills. LearnPress works on the PHP side, but it throws JavaScript errors due to missing WordPress libraries, so I can't tell if the plugins works correctly.

## Description
Polyfills introduced:
- class `WP_Block_Template`
- function `wp_is_block_theme()`

## How has this been tested?
Local installation.

## Screenshots
<!--
Screenshots are very helpful for reviewers to quickly see how your change works.
-->

## Types of changes
- Bug fix

