### PR TITLE
Increase QUnit timeout by 50%

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -568,6 +568,7 @@ module.exports = function(grunt) {
 					'tests/qunit/*.html'
 				],
 				options: {
+					timeout: 7500,
 					httpBase: 'http://localhost:8008',
 					puppeteer: puppeteerOptions
 				}


### PR DESCRIPTION
## Description
Periodically but inconsistently, the QUnit action test is failing, apparently due to a timeout as seen here:
https://github.com/ClassicPress/ClassicPress-v2/actions/runs/5630909803/job/15257331855

## Motivation and context
Re-running the test results in the test passing.
This PR aims to increase the default timout from 5000 milliseconds for 7500 milliseconds, thus increasing the timeout by 50% to see if it will resolve these periodic test failures.

## How has this been tested?
Unit tests will run on this PR

## Screenshots
N/A

## Types of changes
- Bug fix
