### PR TITLE
Fix deprecation when loading "menu" page

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -2097,7 +2097,7 @@ function get_plugin_page_hookname( $plugin_page, $parent_page ) {
 		$page_type = $admin_page_hooks[ $parent ];
 	}
 
-	$plugin_name = preg_replace( '!\.php!', '', $plugin_page );
+	$plugin_name = preg_replace( '!\.php!', '', $plugin_page ?? '' );
 
 	return $page_type . '_page_' . $plugin_name;
 }

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -2097,7 +2097,7 @@ function get_plugin_page_hookname( $plugin_page, $parent_page ) {
 		$page_type = $admin_page_hooks[ $parent ];
 	}
 
-	$plugin_name = preg_replace( '!\.php!', '', $plugin_page ?? '' );
+	$plugin_name = preg_replace( '!\.php!', '', $plugin_page );
 
 	return $page_type . '_page_' . $plugin_name;
 }

--- a/src/wp-admin/nav-menus.php
+++ b/src/wp-admin/nav-menus.php
@@ -28,6 +28,9 @@ if ( ! current_user_can( 'edit_theme_options' ) ) {
 	);
 }
 
+// Used in the HTML title tag.
+$title = __( 'Menus' );
+
 wp_enqueue_script( 'nav-menu' );
 
 if ( wp_is_mobile() ) {


### PR DESCRIPTION
As reported [in this issue](https://github.com/ClassicPress/ClassicPress-v2/issues/156) loading "menu" page triggers a deprecation.
Closes #156.

**Edit: [see this comment](https://github.com/ClassicPress/ClassicPress-v2/pull/160#issuecomment-1647309468).**

## Description
This PR uses the null coalesce operator(`??`) to change the subject to an empty string if the subject is `null`.

## Motivation and context
There are some deprecations that comes from functions calling `preg_replace` or `trim` and similar functions with a `null` subject.
Using the null coalesce operator to force the return of an empty string fixes the deprecation and keep the function working the same way it did before.

## How has this been tested?
Local testing.

## Types of changes
- Bug fix

