### PR TITLE
Fix deprecation when passing `null` to `esc_url`

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4405,6 +4405,10 @@ function esc_sql( $data ) {
  *                those in `$protocols`, or if `$url` contains an empty string.
  */
 function esc_url( $url, $protocols = null, $_context = 'display' ) {
+	if ( is_null( $url ) ) {
+		return '';
+	}
+
 	$original_url = $url;
 
 	if ( '' === $url ) {

--- a/tests/phpunit/tests/formatting/EscUrl.php
+++ b/tests/phpunit/tests/formatting/EscUrl.php
@@ -71,6 +71,10 @@ class Tests_Formatting_EscUrl extends WP_UnitTestCase {
 		$this->assertSame( 'http://баба.org/баба', esc_url( 'баба.org/баба' ) );
 	}
 
+	public function test_null() {
+		$this->assertSame( '', esc_url( null ) );
+	}
+
 	/**
 	 * @covers ::sanitize_url
 	 */

--- a/tests/phpunit/tests/term/wpGenerateTagCloud.php
+++ b/tests/phpunit/tests/term/wpGenerateTagCloud.php
@@ -263,16 +263,6 @@ class Tests_WP_Generate_Tag_Cloud extends WP_UnitTestCase {
 	 * @ticket 5172
 	 */
 	public function test_should_include_tag_link_position_class() {
-		if ( PHP_VERSION_ID >= 80100 ) {
-			/*
-			 * For the time being, ignoring PHP 8.1 "null to non-nullable" deprecations coming in
-			 * via hooked in filter functions until a more structural solution to the
-			 * "missing input validation" conundrum has been architected and implemented.
-			 */
-			$this->expectDeprecation();
-			$this->expectDeprecationMessageMatches( '`Passing null to parameter \#[0-9]+ \(\$[^\)]+\) of type [^ ]+ is deprecated`' );
-		}
-
 		register_taxonomy( 'wptests_tax', 'post' );
 		$term_ids = self::factory()->term->create_many( 3, array( 'taxonomy' => 'wptests_tax' ) );
 


### PR DESCRIPTION
In #123 and also in my logs 
`PHP Deprecated: ltrim(): Passing null to parameter #1 ($string) of type string is deprecated in .../httpdocs/wp-includes/formatting.php on line 4414`
`esc_url` is throwing a deprecation.

## Description
Return an empty string on `esc_url( null )`.
This is the current behavior of `esc_url` and in PHP>=8.1 is throwing a deprecation.

Note that `esc_url( array() )` throws a fatal and that behavior is left intentionally unchanged.

## How has this been tested?
Local testing and unit test.

## Types of changes
- Bug fix

Closes #123.
