### PR TITLE
Add RoboHash default avatar

### DIFF
--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -321,6 +321,7 @@ $avatar_defaults = array(
 	'wavatar'          => __( 'Wavatar (Generated)' ),
 	'monsterid'        => __( 'MonsterID (Generated)' ),
 	'retro'            => __( 'Retro (Generated)' ),
+	'robohash'         => __( 'Robot (Generated)' ),
 );
 /**
  * Filters the default avatars.

--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -321,7 +321,7 @@ $avatar_defaults = array(
 	'wavatar'          => __( 'Wavatar (Generated)' ),
 	'monsterid'        => __( 'MonsterID (Generated)' ),
 	'retro'            => __( 'Retro (Generated)' ),
-	'robohash'         => __( 'Robot (Generated)' ),
+	'robohash'         => __( 'RoboHash (Generated)' ),
 );
 /**
  * Filters the default avatars.


### PR DESCRIPTION
Add already supported RoboHash avatars.
We don't have this in the list, but `get_avatar` declare support for this.

Closes #186.

## How has this been tested?
Local installation.

## Screenshots
<img width="821" alt="image" src="https://github.com/ClassicPress/ClassicPress-v2/assets/29772709/3b40bd11-d1b8-4a3f-8eda-a526a0858fa6">


## Types of changes
- Bug fix
