### PR TITLE
Enable comment form client-side validation

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2653,11 +2653,10 @@ function comment_form( $args = array(), $post = null ) {
 		else :
 
 			printf(
-				'<form action="%s" method="post" id="%s" class="%s"%s>',
+				'<form action="%s" method="post" id="%s" class="%s">',
 				esc_url( $args['action'] ),
 				esc_attr( $args['id_form'] ),
-				esc_attr( $args['class_form'] ),
-				( $html5 ? ' novalidate' : '' )
+				esc_attr( $args['class_form'] )
 			);
 
 			/**


### PR DESCRIPTION
Take advantage of HTML5 validation by removing the novalidate parameter. (See https://github.com/ClassicPress/ClassicPress-v2/issues/193)

## Description
Removes the `novalidate` attribute from the comment form, allowing client-side validation when using HTML5-enabled themes.

## Motivation and context
Client-side validation of the form creates a more user-friendly experience, alleviates server load from having to validate malformed or missing comment meta, and hides ugly error messages when the server fails to validate the comment due to missing or malformed information.

## How has this been tested?
I've tried the code out in Safari, Opera, Firefox, and Chrome (all on MacOS). CanIUse reports a 95% usage rate for HTML5 form types `url` and `email` as well as for the `required` attribute.

## Screenshots

### Before
<img width="829" alt="264076840-53dd8640-287a-436e-8411-25f5296dbd7d" src="https://github.com/ClassicPress/ClassicPress-v2/assets/338467/055fa0b5-4d01-4b0e-a7d4-b658e2ed2342">

### After
<img width="559" alt="264077116-e60f39e1-a85b-402e-aa85-84b7f1026862" src="https://github.com/ClassicPress/ClassicPress-v2/assets/338467/10314547-74e7-45e4-8f8c-4c907ca1c5ac">

<img width="575" alt="264077504-e0feb2c5-ac62-4bc8-9593-1f393b73552b" src="https://github.com/ClassicPress/ClassicPress-v2/assets/338467/f93b9e64-c087-4b9d-88af-6ad4f590d728">

## Types of changes
Minor removal of one conditional HTML5 attribute.
