### PR TITLE
Use details tag to create nav menu

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -3449,10 +3449,9 @@ img {
 }
 
 /* @todo: can we use a common class for these? */
+/* @since CP 2.0.0 removes .accordion-section-title:after */
 .nav-menus-php .item-edit:before,
-.widget-top .widget-action .toggle-indicator:before,
-.control-section .accordion-section-title:after,
-.accordion-section-title:after {
+.widget-top .widget-action .toggle-indicator:before {
 	content: "\f140";
 	font: normal 20px/1 dashicons;
 	speak: never;

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1446,10 +1446,10 @@ function do_accordion_sections( $screen, $context, $data_object ) {
 					}
 
 					/*
-     					* @since CP 2.0.0
-	  				* 
-	  				* Inserts details tag and replaces h3 tag with summary tag for accessibility
-	  				*/
+					 * @since CP 2.0.0
+					 *
+					 * Inserts details tag and replaces h3 tag with summary tag for accessibility
+					 */
 					$i++;
 					?>
 					<li class="control-section">

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1445,31 +1445,31 @@ function do_accordion_sections( $screen, $context, $data_object ) {
 						continue;
 					}
 
+					/*
+     					* @since CP 2.0.0
+	  				* 
+	  				* Inserts details tag and replaces h3 tag with summary tag for accessibility
+	  				*/
 					$i++;
-					$hidden_class = in_array( $box['id'], $hidden, true ) ? 'hide-if-js' : '';
-
-					$open_class = '';
-					if ( ! $first_open && empty( $hidden_class ) ) {
-						$first_open = true;
-						$open_class = 'open';
-					}
 					?>
-					<li class="control-section accordion-section <?php echo $hidden_class; ?> <?php echo $open_class; ?> <?php echo esc_attr( $box['id'] ); ?>" id="<?php echo esc_attr( $box['id'] ); ?>">
-						<h3 class="accordion-section-title hndle" tabindex="0">
-							<?php echo esc_html( $box['title'] ); ?>
-							<span class="screen-reader-text">
-								<?php
-								/* translators: Hidden accessibility text. */
-								_e( 'Press return or enter to open this section' );
-								?>
-							</span>
-						</h3>
-						<div class="accordion-section-content <?php postbox_classes( $box['id'], $page ); ?>">
-							<div class="inside">
-								<?php call_user_func( $box['callback'], $data_object, $box ); ?>
-							</div><!-- .inside -->
-						</div><!-- .accordion-section-content -->
-					</li><!-- .accordion-section -->
+					<li class="control-section">
+						<details class="accordion-section open <?php echo esc_attr( $box['id'] ); ?>" id="<?php echo esc_attr( $box['id'] ); ?>">
+							<summary class="accordion-section-title hndle" tabindex="0">
+								<?php echo esc_html( $box['title'] ); ?>
+								<span class="screen-reader-text">
+									<?php
+									/* translators: Hidden accessibility text. */
+									_e( 'Press return or enter to open this section' );
+									?>
+								</span>
+							</summary>
+							<div class="accordion-section-content <?php postbox_classes( $box['id'], $page ); ?>">
+								<div class="inside">
+									<?php call_user_func( $box['callback'], $data_object, $box ); ?>
+								</div><!-- .inside -->
+							</div><!-- .accordion-section-content -->
+						</details><!-- .accordion-section -->
+					</li><!-- .control-section -->
 					<?php
 				}
 			}

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1431,7 +1431,7 @@ function do_accordion_sections( $screen, $context, $data_object ) {
 
 	$hidden = get_hidden_meta_boxes( $screen );
 	?>
-	<div id="side-sortables" class="accordion-container">
+	<div id="side-sortables">
 		<ul class="outer-border">
 	<?php
 	$i          = 0;


### PR DESCRIPTION
Implements https://github.com/ClassicPress/classicpress-v2/issues/180

## Description
In the PHP file, adds a `details` element within the `li` element and adjusts the classes accordingly. Also replaces the `h3` tag with the `summary` tag.

In the CSS file, remove a class from having an arrow added after it. This arrow is now redundant because the details tag comes with its own arrow (to the left) and does not need any JavaScript (hooked to the removed class) to work.

## Motivation and context
As reported in the Issue mentioned above, this improves accessibility.

## How has this been tested?
Implemented on my localhost test system. It needs wider testing just to make sure it doesn't have hitherto unforeseen consequences elsewhere in the admin.

![Screenshot at 2023-08-31 22-45-04](https://github.com/ClassicPress/ClassicPress-v2/assets/4127662/92df5942-b718-4bfc-ba87-e208895d63a8)
![Screenshot at 2023-08-31 22-45-31](https://github.com/ClassicPress/ClassicPress-v2/assets/4127662/1195e9c0-223e-447b-b018-cb0bbd331110)
![Screenshot at 2023-08-31 22-46-01](https://github.com/ClassicPress/ClassicPress-v2/assets/4127662/6e163fb3-6702-40df-b9a5-c890e6fc000e)

