### PR TITLE
WP-r56475: Database: Remove support for the mysql extension.

### DIFF
--- a/phpcompat.xml.dist
+++ b/phpcompat.xml.dist
@@ -51,9 +51,4 @@
 	<rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_create_ivDeprecatedRemoved">
 		<exclude-pattern>/random_compat/random_bytes_mcrypt\.php$</exclude-pattern>
 	</rule>
-
-	<!-- Allow the WP DB Class for use of `mysql_` extension in PHP < 7.0. -->
-	<rule ref="PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved">
-		<exclude-pattern>/src/wp-includes/class-wpdb\.php</exclude-pattern>
-	</rule>
 </ruleset>

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -818,10 +818,7 @@ class WP_Debug_Data {
 		}
 
 		// Populate the database debug fields.
-		if ( is_resource( $wpdb->dbh ) ) {
-			// Old mysql extension.
-			$extension = 'mysql';
-		} elseif ( is_object( $wpdb->dbh ) ) {
+		if ( is_object( $wpdb->dbh ) ) {
 			// mysqli or PDO.
 			$extension = get_class( $wpdb->dbh );
 		} else {
@@ -831,16 +828,7 @@ class WP_Debug_Data {
 
 		$server = $wpdb->get_var( 'SELECT VERSION()' );
 
-		if ( isset( $wpdb->use_mysqli ) && $wpdb->use_mysqli ) {
 			$client_version = $wpdb->dbh->client_info;
-		} else {
-			// phpcs:ignore WordPress.DB.RestrictedFunctions.mysql_mysql_get_client_info,PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved
-			if ( preg_match( '|[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}|', mysql_get_client_info(), $matches ) ) {
-				$client_version = $matches[0];
-			} else {
-				$client_version = null;
-			}
-		}
 
 		$info['wp-database']['fields']['extension'] = array(
 			'label' => __( 'Extension' ),

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1300,13 +1300,8 @@ class WP_Site_Health {
 			}
 		}
 
-		if ( $wpdb->use_mysqli ) {
 			// phpcs:ignore WordPress.DB.RestrictedFunctions.mysql_mysqli_get_client_info
 			$mysql_client_version = mysqli_get_client_info();
-		} else {
-			// phpcs:ignore WordPress.DB.RestrictedFunctions.mysql_mysql_get_client_info,PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved
-			$mysql_client_version = mysql_get_client_info();
-		}
 
 		/*
 		 * libmysql has supported utf8mb4 since 5.5.3, same as the MySQL server.

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -908,17 +908,17 @@ class wpdb {
 		if ( $this->has_cap( 'collation' ) && ! empty( $charset ) ) {
 			$set_charset_succeeded = true;
 
-				if ( function_exists( 'mysqli_set_charset' ) && $this->has_cap( 'set_charset' ) ) {
-					$set_charset_succeeded = mysqli_set_charset( $dbh, $charset );
-				}
+			if ( function_exists( 'mysqli_set_charset' ) && $this->has_cap( 'set_charset' ) ) {
+				$set_charset_succeeded = mysqli_set_charset( $dbh, $charset );
+			}
 
-				if ( $set_charset_succeeded ) {
-					$query = $this->prepare( 'SET NAMES %s', $charset );
-					if ( ! empty( $collate ) ) {
-						$query .= $this->prepare( ' COLLATE %s', $collate );
-					}
-					mysqli_query( $dbh, $query );
+			if ( $set_charset_succeeded ) {
+				$query = $this->prepare( 'SET NAMES %s', $charset );
+				if ( ! empty( $collate ) ) {
+					$query .= $this->prepare( ' COLLATE %s', $collate );
 				}
+				mysqli_query( $dbh, $query );
+			}
 		}
 	}
 
@@ -939,13 +939,13 @@ class wpdb {
 				return;
 			}
 
-				$modes_array = mysqli_fetch_array( $res );
+			$modes_array = mysqli_fetch_array( $res );
 
-				if ( empty( $modes_array[0] ) ) {
-					return;
-				}
+			if ( empty( $modes_array[0] ) ) {
+				return;
+			}
 
-				$modes_str = $modes_array[0];
+			$modes_str = $modes_array[0];
 
 			if ( empty( $modes_str ) ) {
 				return;
@@ -1266,7 +1266,7 @@ class wpdb {
 
 		if ( $this->dbh ) {
 				$escaped = mysqli_real_escape_string( $this->dbh, $data );
-			} else {
+		} else {
 			$class = get_class( $this );
 
 			wp_load_translations_early();
@@ -1924,43 +1924,43 @@ class wpdb {
 
 		$client_flags = defined( 'MYSQL_CLIENT_FLAGS' ) ? MYSQL_CLIENT_FLAGS : 0;
 
-			/*
-			 * Set the MySQLi error reporting off because WordPress handles its own.
-			 * This is due to the default value change from `MYSQLI_REPORT_OFF`
-			 * to `MYSQLI_REPORT_ERROR|MYSQLI_REPORT_STRICT` in PHP 8.1.
-			 */
-			mysqli_report( MYSQLI_REPORT_OFF );
+		/*
+		 * Set the MySQLi error reporting off because WordPress handles its own.
+		 * This is due to the default value change from `MYSQLI_REPORT_OFF`
+		 * to `MYSQLI_REPORT_ERROR|MYSQLI_REPORT_STRICT` in PHP 8.1.
+		 */
+		mysqli_report( MYSQLI_REPORT_OFF );
 
-			$this->dbh = mysqli_init();
+		$this->dbh = mysqli_init();
 
-			$host    = $this->dbhost;
-			$port    = null;
-			$socket  = null;
-			$is_ipv6 = false;
+		$host    = $this->dbhost;
+		$port    = null;
+		$socket  = null;
+		$is_ipv6 = false;
 
-			$host_data = $this->parse_db_host( $this->dbhost );
-			if ( $host_data ) {
-				list( $host, $port, $socket, $is_ipv6 ) = $host_data;
-			}
+		$host_data = $this->parse_db_host( $this->dbhost );
+		if ( $host_data ) {
+			list( $host, $port, $socket, $is_ipv6 ) = $host_data;
+		}
 
-			/*
-			 * If using the `mysqlnd` library, the IPv6 address needs to be enclosed
-			 * in square brackets, whereas it doesn't while using the `libmysqlclient` library.
-			 * @see https://bugs.php.net/bug.php?id=67563
-			 */
-			if ( $is_ipv6 && extension_loaded( 'mysqlnd' ) ) {
-				$host = "[$host]";
-			}
+		/*
+		 * If using the `mysqlnd` library, the IPv6 address needs to be enclosed
+		 * in square brackets, whereas it doesn't while using the `libmysqlclient` library.
+		 * @see https://bugs.php.net/bug.php?id=67563
+		 */
+		if ( $is_ipv6 && extension_loaded( 'mysqlnd' ) ) {
+			$host = "[$host]";
+		}
 
-			if ( WP_DEBUG ) {
-				mysqli_real_connect( $this->dbh, $host, $this->dbuser, $this->dbpassword, null, $port, $socket, $client_flags );
-			} else {
-				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-				@mysqli_real_connect( $this->dbh, $host, $this->dbuser, $this->dbpassword, null, $port, $socket, $client_flags );
-			}
+		if ( WP_DEBUG ) {
+			mysqli_real_connect( $this->dbh, $host, $this->dbuser, $this->dbpassword, null, $port, $socket, $client_flags );
+		} else {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			@mysqli_real_connect( $this->dbh, $host, $this->dbuser, $this->dbpassword, null, $port, $socket, $client_flags );
+		}
 
-			if ( $this->dbh->connect_errno ) {
-				$this->dbh = null;
+		if ( $this->dbh->connect_errno ) {
+			$this->dbh = null;
 		}
 
 		if ( ! $this->dbh && $allow_bail ) {
@@ -2086,9 +2086,9 @@ class wpdb {
 	 * @return bool|void True if the connection is up.
 	 */
 	public function check_connection( $allow_bail = true ) {
-			if ( ! empty( $this->dbh ) && mysqli_ping( $this->dbh ) ) {
-				return true;
-			}
+		if ( ! empty( $this->dbh ) && mysqli_ping( $this->dbh ) ) {
+			return true;
+		}
 
 		$error_reporting = false;
 
@@ -2224,13 +2224,13 @@ class wpdb {
 		// Database server has gone away, try to reconnect.
 		$mysql_errno = 0;
 
-				if ( $this->dbh instanceof mysqli ) {
-					$mysql_errno = mysqli_errno( $this->dbh );
-				} else {
-					// $dbh is defined, but isn't a real connection.
-					// Something has gone horribly wrong, let's try a reconnect.
-					$mysql_errno = 2006;
-				}
+		if ( $this->dbh instanceof mysqli ) {
+			$mysql_errno = mysqli_errno( $this->dbh );
+		} else {
+			// $dbh is defined, but isn't a real connection.
+			// Something has gone horribly wrong, let's try a reconnect.
+			$mysql_errno = 2006;
+		}
 
 		if ( empty( $this->dbh ) || 2006 === $mysql_errno ) {
 			if ( $this->check_connection() ) {
@@ -2242,11 +2242,11 @@ class wpdb {
 		}
 
 		// If there is an error then take note of it.
-			if ( $this->dbh instanceof mysqli ) {
-				$this->last_error = mysqli_error( $this->dbh );
-			} else {
-				$this->last_error = __( 'Unable to retrieve the error message from MySQL' );
-			}
+		if ( $this->dbh instanceof mysqli ) {
+			$this->last_error = mysqli_error( $this->dbh );
+		} else {
+			$this->last_error = __( 'Unable to retrieve the error message from MySQL' );
+		}
 
 		if ( $this->last_error ) {
 			// Clear insert_id on a subsequent failed insert.
@@ -3685,11 +3685,11 @@ class wpdb {
 			return;
 		}
 
-			$num_fields = mysqli_num_fields( $this->result );
+		$num_fields = mysqli_num_fields( $this->result );
 
-			for ( $i = 0; $i < $num_fields; $i++ ) {
-				$this->col_info[ $i ] = mysqli_fetch_field( $this->result );
-			}
+		for ( $i = 0; $i < $num_fields; $i++ ) {
+			$this->col_info[ $i ] = mysqli_fetch_field( $this->result );
+		}
 	}
 
 	/**
@@ -3761,11 +3761,11 @@ class wpdb {
 		if ( $this->show_errors ) {
 			$error = '';
 
-				if ( $this->dbh instanceof mysqli ) {
-					$error = mysqli_error( $this->dbh );
-				} elseif ( mysqli_connect_errno() ) {
-					$error = mysqli_connect_error();
-				}
+			if ( $this->dbh instanceof mysqli ) {
+				$error = mysqli_error( $this->dbh );
+			} elseif ( mysqli_connect_errno() ) {
+				$error = mysqli_connect_error();
+			}
 
 			if ( $error ) {
 				$message = '<p><code>' . $error . "</code></p>\n" . $message;

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -142,16 +142,14 @@ class wpdb {
 	 *
 	 * Possible values:
 	 *
-	 * - For successful SELECT, SHOW, DESCRIBE, or EXPLAIN queries:
-	 *   - `mysqli_result` instance when the `mysqli` driver is in use
-	 *   - `resource` when the older `mysql` driver is in use
+	 * - `mysqli_result` instance for successful SELECT, SHOW, DESCRIBE, or EXPLAIN queries
 	 * - `true` for other query types that were successful
 	 * - `null` if a query is yet to be made or if the result has since been flushed
 	 * - `false` if the query returned an error
 	 *
 	 * @since 0.71
 	 *
-	 * @var mysqli_result|resource|bool|null
+	 * @var mysqli_result|bool|null
 	 */
 	protected $result;
 
@@ -604,14 +602,13 @@ class wpdb {
 	 *
 	 * Possible values:
 	 *
-	 * - `mysqli` instance when the `mysqli` driver is in use
-	 * - `resource` when the older `mysql` driver is in use
+	 * - `mysqli` instance during normal operation
 	 * - `null` if the connection is yet to be made or has been closed
 	 * - `false` if the connection has failed
 	 *
 	 * @since 0.71
 	 *
-	 * @var mysqli|resource|false|null
+	 * @var mysqli|false|null
 	 */
 	protected $dbh;
 
@@ -694,15 +691,6 @@ class wpdb {
 	private $allow_unsafe_unquoted_parameters = true;
 
 	/**
-	 * Whether to use mysqli over mysql. Default false.
-	 *
-	 * @since 3.9.0
-	 *
-	 * @var bool
-	 */
-	private $use_mysqli = false;
-
-	/**
 	 * Whether we've managed to successfully connect at some point.
 	 *
 	 * @since 3.9.0
@@ -749,15 +737,6 @@ class wpdb {
 	public function __construct( $dbuser, $dbpassword, $dbname, $dbhost ) {
 		if ( WP_DEBUG && WP_DEBUG_DISPLAY ) {
 			$this->show_errors();
-		}
-
-		// Use the `mysqli` extension if it exists unless `WP_USE_EXT_MYSQL` is defined as true.
-		if ( function_exists( 'mysqli_connect' ) ) {
-			$this->use_mysqli = true;
-
-			if ( defined( 'WP_USE_EXT_MYSQL' ) ) {
-				$this->use_mysqli = ! WP_USE_EXT_MYSQL;
-			}
 		}
 
 		$this->dbuser     = $dbuser;
@@ -880,7 +859,7 @@ class wpdb {
 	 * }
 	 */
 	public function determine_charset( $charset, $collate ) {
-		if ( ( $this->use_mysqli && ! ( $this->dbh instanceof mysqli ) ) || empty( $this->dbh ) ) {
+		if ( ( ! ( $this->dbh instanceof mysqli ) ) || empty( $this->dbh ) ) {
 			return compact( 'charset', 'collate' );
 		}
 
@@ -915,7 +894,7 @@ class wpdb {
 	 *
 	 * @since 3.1.0
 	 *
-	 * @param mysqli|resource $dbh     The connection returned by `mysqli_connect()` or `mysql_connect()`.
+	 * @param mysqli $dbh     The connection returned by `mysqli_connect()`.
 	 * @param string          $charset Optional. The character set. Default null.
 	 * @param string          $collate Optional. The collation. Default null.
 	 */
@@ -929,7 +908,6 @@ class wpdb {
 		if ( $this->has_cap( 'collation' ) && ! empty( $charset ) ) {
 			$set_charset_succeeded = true;
 
-			if ( $this->use_mysqli ) {
 				if ( function_exists( 'mysqli_set_charset' ) && $this->has_cap( 'set_charset' ) ) {
 					$set_charset_succeeded = mysqli_set_charset( $dbh, $charset );
 				}
@@ -941,18 +919,6 @@ class wpdb {
 					}
 					mysqli_query( $dbh, $query );
 				}
-			} else {
-				if ( function_exists( 'mysql_set_charset' ) && $this->has_cap( 'set_charset' ) ) {
-					$set_charset_succeeded = mysql_set_charset( $charset, $dbh );
-				}
-				if ( $set_charset_succeeded ) {
-					$query = $this->prepare( 'SET NAMES %s', $charset );
-					if ( ! empty( $collate ) ) {
-						$query .= $this->prepare( ' COLLATE %s', $collate );
-					}
-					mysql_query( $query, $dbh );
-				}
-			}
 		}
 	}
 
@@ -967,25 +933,19 @@ class wpdb {
 	 */
 	public function set_sql_mode( $modes = array() ) {
 		if ( empty( $modes ) ) {
-			if ( $this->use_mysqli ) {
 				$res = mysqli_query( $this->dbh, 'SELECT @@SESSION.sql_mode' );
-			} else {
-				$res = mysql_query( 'SELECT @@SESSION.sql_mode', $this->dbh );
-			}
 
 			if ( empty( $res ) ) {
 				return;
 			}
 
-			if ( $this->use_mysqli ) {
 				$modes_array = mysqli_fetch_array( $res );
+
 				if ( empty( $modes_array[0] ) ) {
 					return;
 				}
+
 				$modes_str = $modes_array[0];
-			} else {
-				$modes_str = mysql_result( $res, 0 );
-			}
 
 			if ( empty( $modes_str ) ) {
 				return;
@@ -1013,11 +973,7 @@ class wpdb {
 
 		$modes_str = implode( ',', $modes );
 
-		if ( $this->use_mysqli ) {
 			mysqli_query( $this->dbh, "SET SESSION sql_mode='$modes_str'" );
-		} else {
-			mysql_query( "SET SESSION sql_mode='$modes_str'", $this->dbh );
-		}
 	}
 
 	/**
@@ -1221,7 +1177,7 @@ class wpdb {
 	 * @since 0.71
 	 *
 	 * @param string          $db  Database name.
-	 * @param mysqli|resource $dbh Optional. Database connection.
+	 * @param mysqli $dbh Optional. Database connection.
 	 *                             Defaults to the current database handle.
 	 */
 	public function select( $db, $dbh = null ) {
@@ -1229,11 +1185,8 @@ class wpdb {
 			$dbh = $this->dbh;
 		}
 
-		if ( $this->use_mysqli ) {
 			$success = mysqli_select_db( $dbh, $db );
-		} else {
-			$success = mysql_select_db( $db, $dbh );
-		}
+
 		if ( ! $success ) {
 			$this->ready = false;
 			if ( ! did_action( 'template_redirect' ) ) {
@@ -1297,12 +1250,11 @@ class wpdb {
 	}
 
 	/**
-	 * Real escape, using mysqli_real_escape_string() or mysql_real_escape_string().
+	 * Real escape using mysqli_real_escape_string().
 	 *
 	 * @since 2.8.0
 	 *
 	 * @see mysqli_real_escape_string()
-	 * @see mysql_real_escape_string()
 	 *
 	 * @param string $data String to escape.
 	 * @return string Escaped string.
@@ -1313,12 +1265,8 @@ class wpdb {
 		}
 
 		if ( $this->dbh ) {
-			if ( $this->use_mysqli ) {
 				$escaped = mysqli_real_escape_string( $this->dbh, $data );
 			} else {
-				$escaped = mysql_real_escape_string( $data, $this->dbh );
-			}
-		} else {
 			$class = get_class( $this );
 
 			wp_load_translations_early();
@@ -1820,12 +1768,9 @@ class wpdb {
 		global $EZSQL_ERROR;
 
 		if ( ! $str ) {
-			if ( $this->use_mysqli ) {
 				$str = mysqli_error( $this->dbh );
-			} else {
-				$str = mysql_error( $this->dbh );
-			}
 		}
+
 		$EZSQL_ERROR[] = array(
 			'query'     => $this->last_query,
 			'error_str' => $str,
@@ -1947,7 +1892,7 @@ class wpdb {
 		$this->num_rows      = 0;
 		$this->last_error    = '';
 
-		if ( $this->use_mysqli && $this->result instanceof mysqli_result ) {
+		if ( $this->result instanceof mysqli_result ) {
 			mysqli_free_result( $this->result );
 			$this->result = null;
 
@@ -1960,8 +1905,6 @@ class wpdb {
 			while ( mysqli_more_results( $this->dbh ) ) {
 				mysqli_next_result( $this->dbh );
 			}
-		} elseif ( is_resource( $this->result ) ) {
-			mysql_free_result( $this->result );
 		}
 	}
 
@@ -1979,14 +1922,8 @@ class wpdb {
 	public function db_connect( $allow_bail = true ) {
 		$this->is_mysql = true;
 
-		/*
-		 * Deprecated in 3.9+ when using MySQLi. No equivalent
-		 * $new_link parameter exists for mysqli_* functions.
-		 */
-		$new_link     = defined( 'MYSQL_NEW_LINK' ) ? MYSQL_NEW_LINK : true;
 		$client_flags = defined( 'MYSQL_CLIENT_FLAGS' ) ? MYSQL_CLIENT_FLAGS : 0;
 
-		if ( $this->use_mysqli ) {
 			/*
 			 * Set the MySQLi error reporting off because WordPress handles its own.
 			 * This is due to the default value change from `MYSQLI_REPORT_OFF`
@@ -2024,35 +1961,6 @@ class wpdb {
 
 			if ( $this->dbh->connect_errno ) {
 				$this->dbh = null;
-
-				/*
-				 * It's possible ext/mysqli is misconfigured. Fall back to ext/mysql if:
-				 *  - We haven't previously connected, and
-				 *  - WP_USE_EXT_MYSQL isn't set to false, and
-				 *  - ext/mysql is loaded.
-				 */
-				$attempt_fallback = true;
-
-				if ( $this->has_connected ) {
-					$attempt_fallback = false;
-				} elseif ( defined( 'WP_USE_EXT_MYSQL' ) && ! WP_USE_EXT_MYSQL ) {
-					$attempt_fallback = false;
-				} elseif ( ! function_exists( 'mysql_connect' ) ) {
-					$attempt_fallback = false;
-				}
-
-				if ( $attempt_fallback ) {
-					$this->use_mysqli = false;
-					return $this->db_connect( $allow_bail );
-				}
-			}
-		} else {
-			if ( WP_DEBUG ) {
-				$this->dbh = mysql_connect( $this->dbhost, $this->dbuser, $this->dbpassword, $new_link, $client_flags );
-			} else {
-				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-				$this->dbh = @mysql_connect( $this->dbhost, $this->dbuser, $this->dbpassword, $new_link, $client_flags );
-			}
 		}
 
 		if ( ! $this->dbh && $allow_bail ) {
@@ -2178,15 +2086,9 @@ class wpdb {
 	 * @return bool|void True if the connection is up.
 	 */
 	public function check_connection( $allow_bail = true ) {
-		if ( $this->use_mysqli ) {
 			if ( ! empty( $this->dbh ) && mysqli_ping( $this->dbh ) ) {
 				return true;
 			}
-		} else {
-			if ( ! empty( $this->dbh ) && mysql_ping( $this->dbh ) ) {
-				return true;
-			}
-		}
 
 		$error_reporting = false;
 
@@ -2321,8 +2223,7 @@ class wpdb {
 
 		// Database server has gone away, try to reconnect.
 		$mysql_errno = 0;
-		if ( ! empty( $this->dbh ) ) {
-			if ( $this->use_mysqli ) {
+
 				if ( $this->dbh instanceof mysqli ) {
 					$mysql_errno = mysqli_errno( $this->dbh );
 				} else {
@@ -2330,14 +2231,6 @@ class wpdb {
 					// Something has gone horribly wrong, let's try a reconnect.
 					$mysql_errno = 2006;
 				}
-			} else {
-				if ( is_resource( $this->dbh ) ) {
-					$mysql_errno = mysql_errno( $this->dbh );
-				} else {
-					$mysql_errno = 2006;
-				}
-			}
-		}
 
 		if ( empty( $this->dbh ) || 2006 === $mysql_errno ) {
 			if ( $this->check_connection() ) {
@@ -2349,19 +2242,11 @@ class wpdb {
 		}
 
 		// If there is an error then take note of it.
-		if ( $this->use_mysqli ) {
 			if ( $this->dbh instanceof mysqli ) {
 				$this->last_error = mysqli_error( $this->dbh );
 			} else {
 				$this->last_error = __( 'Unable to retrieve the error message from MySQL' );
 			}
-		} else {
-			if ( is_resource( $this->dbh ) ) {
-				$this->last_error = mysql_error( $this->dbh );
-			} else {
-				$this->last_error = __( 'Unable to retrieve the error message from MySQL' );
-			}
-		}
 
 		if ( $this->last_error ) {
 			// Clear insert_id on a subsequent failed insert.
@@ -2376,30 +2261,20 @@ class wpdb {
 		if ( preg_match( '/^\s*(create|alter|truncate|drop)\s/i', $query ) ) {
 			$return_val = $this->result;
 		} elseif ( preg_match( '/^\s*(insert|delete|update|replace)\s/i', $query ) ) {
-			if ( $this->use_mysqli ) {
 				$this->rows_affected = mysqli_affected_rows( $this->dbh );
-			} else {
-				$this->rows_affected = mysql_affected_rows( $this->dbh );
-			}
+
 			// Take note of the insert_id.
 			if ( preg_match( '/^\s*(insert|replace)\s/i', $query ) ) {
-				if ( $this->use_mysqli ) {
 					$this->insert_id = mysqli_insert_id( $this->dbh );
-				} else {
-					$this->insert_id = mysql_insert_id( $this->dbh );
-				}
 			}
+
 			// Return number of rows affected.
 			$return_val = $this->rows_affected;
 		} else {
 			$num_rows = 0;
-			if ( $this->use_mysqli && $this->result instanceof mysqli_result ) {
+
+			if ( $this->result instanceof mysqli_result ) {
 				while ( $row = mysqli_fetch_object( $this->result ) ) {
-					$this->last_result[ $num_rows ] = $row;
-					$num_rows++;
-				}
-			} elseif ( is_resource( $this->result ) ) {
-				while ( $row = mysql_fetch_object( $this->result ) ) {
 					$this->last_result[ $num_rows ] = $row;
 					$num_rows++;
 				}
@@ -2414,7 +2289,7 @@ class wpdb {
 	}
 
 	/**
-	 * Internal function to perform the mysql_query() call.
+	 * Internal function to perform the mysqli_query() call.
 	 *
 	 * @since 3.9.0
 	 *
@@ -2427,11 +2302,10 @@ class wpdb {
 			$this->timer_start();
 		}
 
-		if ( ! empty( $this->dbh ) && $this->use_mysqli ) {
+		if ( ! empty( $this->dbh ) ) {
 			$this->result = mysqli_query( $this->dbh, $query );
-		} elseif ( ! empty( $this->dbh ) ) {
-			$this->result = mysql_query( $query, $this->dbh );
 		}
+
 		$this->num_queries++;
 
 		if ( defined( 'SAVEQUERIES' ) && SAVEQUERIES ) {
@@ -3601,11 +3475,7 @@ class wpdb {
 					if ( $this->charset ) {
 						$connection_charset = $this->charset;
 					} else {
-						if ( $this->use_mysqli ) {
 							$connection_charset = mysqli_character_set_name( $this->dbh );
-						} else {
-							$connection_charset = mysql_client_encoding();
-						}
 					}
 
 					if ( is_array( $value['length'] ) ) {
@@ -3815,17 +3685,11 @@ class wpdb {
 			return;
 		}
 
-		if ( $this->use_mysqli ) {
 			$num_fields = mysqli_num_fields( $this->result );
+
 			for ( $i = 0; $i < $num_fields; $i++ ) {
 				$this->col_info[ $i ] = mysqli_fetch_field( $this->result );
 			}
-		} else {
-			$num_fields = mysql_num_fields( $this->result );
-			for ( $i = 0; $i < $num_fields; $i++ ) {
-				$this->col_info[ $i ] = mysql_fetch_field( $this->result, $i );
-			}
-		}
 	}
 
 	/**
@@ -3897,19 +3761,11 @@ class wpdb {
 		if ( $this->show_errors ) {
 			$error = '';
 
-			if ( $this->use_mysqli ) {
 				if ( $this->dbh instanceof mysqli ) {
 					$error = mysqli_error( $this->dbh );
 				} elseif ( mysqli_connect_errno() ) {
 					$error = mysqli_connect_error();
 				}
-			} else {
-				if ( is_resource( $this->dbh ) ) {
-					$error = mysql_error( $this->dbh );
-				} else {
-					$error = mysql_error();
-				}
-			}
 
 			if ( $error ) {
 				$message = '<p><code>' . $error . "</code></p>\n" . $message;
@@ -3940,11 +3796,7 @@ class wpdb {
 			return false;
 		}
 
-		if ( $this->use_mysqli ) {
 			$closed = mysqli_close( $this->dbh );
-		} else {
-			$closed = mysql_close( $this->dbh );
-		}
 
 		if ( $closed ) {
 			$this->dbh           = null;
@@ -4057,11 +3909,8 @@ class wpdb {
 				if ( version_compare( $db_version, '5.5.3', '<' ) ) {
 					return false;
 				}
-				if ( $this->use_mysqli ) {
+
 					$client_version = mysqli_get_client_info();
-				} else {
-					$client_version = mysql_get_client_info();
-				}
 
 				/*
 				 * libmysql has supported utf8mb4 since 5.5.3, same as the MySQL server.
@@ -4109,19 +3958,13 @@ class wpdb {
 	}
 
 	/**
-	 * Retrieves full database server information.
+	 * Returns the version of the MySQL server.
 	 *
 	 * @since 5.5.0
 	 *
-	 * @return string|false Server info on success, false on failure.
+	 * @return string Server version as a string.
 	 */
 	public function db_server_info() {
-		if ( $this->use_mysqli ) {
-			$server_info = mysqli_get_server_info( $this->dbh );
-		} else {
-			$server_info = mysql_get_server_info( $this->dbh );
-		}
-
-		return $server_info;
+		return mysqli_get_server_info( $this->dbh );
 	}
 }

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -130,11 +130,7 @@ function wp_populate_basic_auth_from_authorization_header() {
 }
 
 /**
-<<<<<<< HEAD
- * Check for the required PHP version, and the MySQL extension or
-=======
  * Checks for the required PHP version, and the mysqli extension or
->>>>>>> f71140438b (Database: Remove support for the `mysql` extension.)
  * a database drop-in.
  *
  * Dies if requirements are not met.
@@ -162,18 +158,11 @@ function wp_check_php_mysql_versions() {
 		exit( 1 );
 	}
 
-<<<<<<< HEAD
-	if ( ! function_exists( 'mysqli_connect' ) && ! function_exists( 'mysql_connect' )
-		// This runs before default constants are defined, so we can't assume WP_CONTENT_DIR is set yet.
-		&& ( defined( 'WP_CONTENT_DIR' ) && ! file_exists( WP_CONTENT_DIR . '/db.php' )
-			|| ! file_exists( ABSPATH . 'wp-content/db.php' ) )
-=======
 	// This runs before default constants are defined, so we can't assume WP_CONTENT_DIR is set yet.
 	$wp_content_dir = defined( 'WP_CONTENT_DIR' ) ? WP_CONTENT_DIR : ABSPATH . 'wp-content';
 
 	if ( ! function_exists( 'mysqli_connect' )
 		&& ! file_exists( $wp_content_dir . '/db.php' )
->>>>>>> f71140438b (Database: Remove support for the `mysql` extension.)
 	) {
 		require_once ABSPATH . WPINC . '/functions.php';
 		wp_load_translations_early();

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -130,7 +130,11 @@ function wp_populate_basic_auth_from_authorization_header() {
 }
 
 /**
+<<<<<<< HEAD
  * Check for the required PHP version, and the MySQL extension or
+=======
+ * Checks for the required PHP version, and the mysqli extension or
+>>>>>>> f71140438b (Database: Remove support for the `mysql` extension.)
  * a database drop-in.
  *
  * Dies if requirements are not met.
@@ -158,10 +162,18 @@ function wp_check_php_mysql_versions() {
 		exit( 1 );
 	}
 
+<<<<<<< HEAD
 	if ( ! function_exists( 'mysqli_connect' ) && ! function_exists( 'mysql_connect' )
 		// This runs before default constants are defined, so we can't assume WP_CONTENT_DIR is set yet.
 		&& ( defined( 'WP_CONTENT_DIR' ) && ! file_exists( WP_CONTENT_DIR . '/db.php' )
 			|| ! file_exists( ABSPATH . 'wp-content/db.php' ) )
+=======
+	// This runs before default constants are defined, so we can't assume WP_CONTENT_DIR is set yet.
+	$wp_content_dir = defined( 'WP_CONTENT_DIR' ) ? WP_CONTENT_DIR : ABSPATH . 'wp-content';
+
+	if ( ! function_exists( 'mysqli_connect' )
+		&& ! file_exists( $wp_content_dir . '/db.php' )
+>>>>>>> f71140438b (Database: Remove support for the `mysql` extension.)
 	) {
 		require_once ABSPATH . WPINC . '/functions.php';
 		wp_load_translations_early();

--- a/tests/phpunit/includes/utils.php
+++ b/tests/phpunit/includes/utils.php
@@ -556,7 +556,6 @@ class WpdbExposedMethodsForTesting extends wpdb {
 	public function __construct() {
 		global $wpdb;
 		$this->dbh         = $wpdb->dbh;
-		$this->use_mysqli  = $wpdb->use_mysqli;
 		$this->is_mysql    = $wpdb->is_mysql;
 		$this->ready       = true;
 		$this->field_types = $wpdb->field_types;

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -713,9 +713,6 @@ class Tests_DB extends WP_UnitTestCase {
 	 */
 	public function test_mysqli_flush_sync() {
 		global $wpdb;
-		if ( ! $wpdb->use_mysqli ) {
-			$this->markTestSkipped( 'mysqli not being used.' );
-		}
 
 		$suppress = $wpdb->suppress_errors( true );
 


### PR DESCRIPTION
The `mysql` extension is no longer used in PHP 7 or above. There's a good amount of conditional code in `wpdb` and the health checks that can be removed now that only the `mysqli` functions are used.

Fixes https://core.trac.wordpress.org/ticket/59118

Conflicts:
- src/wp-includes/load.php

---

Merges https://core.trac.wordpress.org/changeset/56475 / https://github.com/WordPress/wordpress-develop/commit/f71140438b to ClassicPress.