### PR TITLE
Add Previous and Next buttons alongside Add New button on single post screen in admin

### DIFF
--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -431,6 +431,46 @@ echo esc_html( $title );
 <?php
 if ( isset( $post_new_file ) && current_user_can( $post_type_object->cap->create_posts ) ) {
 	echo ' <a href="' . esc_url( admin_url( $post_new_file ) ) . '" class="page-title-action">' . esc_html( $post_type_object->labels->add_new ) . '</a>';
+
+	/**
+	 * Adds Previous and Next links alongside Add New link.
+	 * Setting works per user per post type.
+	 *
+	 * @since CP 2.0.0
+	 */
+	$nav_display = 'inline';
+	$metaboxhidden = (array) get_user_meta( get_current_user_id(), 'metaboxhidden_' . $post_type_object->name, true );
+
+	if ( in_array( 'adminpostnavspan', $metaboxhidden ) ) {
+		$nav_display = 'none';
+	}
+
+	$next_post = get_next_post();
+	$previous_post = get_previous_post();
+
+	echo '<span id="adminpostnavspan" class="postbox" style="background: transparent; border: none; box-shadow: none; display: ' . $nav_display . ';">';
+
+	if ( ! empty( $previous_post ) ) {
+
+		$previous_link = esc_url( admin_url() . 'post.php?post=' . $previous_post->ID . '&amp;action=edit' );
+
+		$prev_title = _x( 'Previous post: ', 'Admin Post Navigation' ) . esc_attr( $previous_post->post_title );
+
+		echo ' <a href="' . $previous_link . '" id="adminpostnav-prev" title="' . $prev_title . ' " class="add-new-h2">' . _x( '&larr; Previous', 'Admin Post Navigation' ) . '</a>';
+
+	}
+
+	if ( ! empty( $next_post ) ) {
+
+		$next_link = esc_url( admin_url() . 'post.php?post=' . $next_post->ID . '&amp;action=edit' );
+
+		$next_title = _x( 'Next post: ', 'Admin Post Navigation' ) . esc_attr( $next_post->post_title );
+
+		echo ' <a href="' . $next_link . '" id="adminpostnav-next" title="' . $next_title . ' " class="add-new-h2">' . _x( 'Next &rarr;', 'Admin Post Navigation' ) . '</a>';
+
+	}
+
+	echo '</span>';
 }
 ?>
 

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -436,7 +436,7 @@ if ( isset( $post_new_file ) && current_user_can( $post_type_object->cap->create
 	 * Adds Previous and Next links alongside Add New link.
 	 * Setting works per user per post type.
 	 *
-	 * @since CP 2.0.0
+	 * @since CP-2.0.0
 	 */
 	$nav_display = 'inline';
 	$metaboxhidden = (array) get_user_meta( get_current_user_id(), 'metaboxhidden_' . $post_type_object->name, true );

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -975,9 +975,30 @@ final class WP_Screen {
 		$this->_screen_settings = '';
 
 		if ( 'post' === $this->base ) {
-			$expand                 = '<fieldset class="editor-expand hidden"><legend>' . __( 'Additional settings' ) . '</legend><label for="editor-expand-toggle">';
-			$expand                .= '<input type="checkbox" id="editor-expand-toggle"' . checked( get_user_setting( 'editor_expand', 'on' ), 'on', false ) . ' />';
-			$expand                .= __( 'Enable full-height editor and distraction-free functionality.' ) . '</label></fieldset>';
+
+			$expand = '<fieldset class="editor-expand hidden"><legend>' . __( 'Additional settings' ) . '</legend><label for="editor-expand-toggle">';
+
+			$expand .= '<input type="checkbox" id="editor-expand-toggle"' . checked( get_user_setting( 'editor_expand', 'on' ), 'on', false ) . '>';
+
+			$expand .= __( 'Enable full-height editor and distraction-free functionality.' ) . '</label>';
+
+			/**
+			 * Adds Previous and Next links alongside Add New link.
+			 *
+			 * @since CP 2.0.0
+			 */
+			$metaboxhidden = (array) get_user_meta( get_current_user_id(), 'metaboxhidden_' . $this->post_type, true );
+
+			$checked = checked( ! in_array( 'adminpostnavspan', $metaboxhidden ) );
+
+			$expand .= '<label for="adminpostnav-hide">';
+
+			$expand .= '<input id="adminpostnav-hide" class="hide-postbox-tog" name="adminpostnav-hide" type="checkbox" value="adminpostnavspan" ' . esc_attr( $checked ) . '>';
+
+			$expand .= _x( 'Enable Previous and Next buttons', 'Admin Post Navigation' );
+
+			$expand .= '</label></fieldset>';
+
 			$this->_screen_settings = $expand;
 		}
 

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -989,7 +989,7 @@ final class WP_Screen {
 			 */
 			$metaboxhidden = (array) get_user_meta( get_current_user_id(), 'metaboxhidden_' . $this->post_type, true );
 
-			$checked = checked( ! in_array( 'adminpostnavspan', $metaboxhidden ) );
+			$checked = checked( ! in_array( 'adminpostnavspan', $metaboxhidden ), true, false );
 
 			$expand .= '<label for="adminpostnav-hide">';
 

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -985,7 +985,7 @@ final class WP_Screen {
 			/**
 			 * Adds Previous and Next links alongside Add New link.
 			 *
-			 * @since CP 2.0.0
+			 * @since CP-2.0.0
 			 */
 			$metaboxhidden = (array) get_user_meta( get_current_user_id(), 'metaboxhidden_' . $this->post_type, true );
 


### PR DESCRIPTION
This PR adds two new buttons alongside the Add New button on a single post screen in the admin. They point to the previous and next posts of that particular post type.

These buttons can be hidden if desired using the toggle (also included in this PR) for each post's screen options. The toggle works per user per post type.

## Description
This was previously proposed for CP v1 at https://github.com/ClassicPress/ClassicPress/pull/849

## Motivation and context
Proposed for v1 after another user (not me) requested it. I already use a plugin to achieve the same thing via JavaScript, but the method in this PR is much more robust.

## How has this been tested?
On my localhost test site.

## Screenshots
![Screenshot at 2023-09-17 15-13-49](https://github.com/ClassicPress/ClassicPress-v2/assets/4127662/1ee6b1d5-abd5-4e0a-aeb6-9dc95208976d)

## Types of changes
New feature
