### PR TITLE
WP-r56622: Add `sys_get_temp_dir()` to `open_basedir` tests

### DIFF
--- a/tests/phpunit/tests/admin/wpAutomaticUpdater.php
+++ b/tests/phpunit/tests/admin/wpAutomaticUpdater.php
@@ -610,7 +610,7 @@ class Tests_Admin_WpAutomaticUpdater extends WP_UnitTestCase {
 
 		$open_basedir_backup = ini_get( 'open_basedir' );
 		// Allow access to the directory one level above the repository.
-		ini_set( 'open_basedir', wp_normalize_path( $abspath_grandparent ) );
+		ini_set( 'open_basedir', sys_get_temp_dir() . PATH_SEPARATOR . wp_normalize_path( $abspath_grandparent ) );
 
 		// Checking an allowed directory should succeed.
 		$actual = self::$updater->is_allowed_dir( wp_normalize_path( ABSPATH ) );
@@ -645,7 +645,7 @@ class Tests_Admin_WpAutomaticUpdater extends WP_UnitTestCase {
 
 		$open_basedir_backup = ini_get( 'open_basedir' );
 		// Allow access to the directory one level above the repository.
-		ini_set( 'open_basedir', wp_normalize_path( $abspath_grandparent ) );
+		ini_set( 'open_basedir', sys_get_temp_dir() . PATH_SEPARATOR . wp_normalize_path( $abspath_grandparent ) );
 
 		// Checking a directory not within the allowed path should trigger an `open_basedir` warning.
 		$actual = self::$updater->is_allowed_dir( '/.git' );


### PR DESCRIPTION
## Description
WP-r56622: Build/Test Tools: Add `sys_get_temp_dir()` to `open_basedir` tests.

In PHPUnit 10.3.5, 9.6.13 and 8.5.34, the child processes used for process isolation now use temporary files to communicate their result to the parent process.

This caused a failure in some tests that set the `open_basedir` PHP directive to a value that did not include `sys_get_temp_dir()`.

This adds `sys_get_temp_dir()` to the `open_basedir` value set by the tests to ensure that permission is still granted for the temporary directory.

PHPUnit uses `sys_get_temp_dir()`. To ensure the result is the same, Core's `get_temp_dir()` function is not used.

References:
- https://github.com/sebastianbergmann/phpunit/issues/5356

WP:Props desrosj, mukesh27, SergeyBiryukov, costdev. Fixes https://core.trac.wordpress.org/ticket/59394.

---

Merges https://core.trac.wordpress.org/changeset/56622 / WordPress/wordpress-develop@7d96189ba1 to ClassicPress.

## Motivation and context
Hopefully, this will fix 2 failing PHPUnit tests in core.

## How has this been tested?
Upstream backport and unit tests will run on PR.

## Screenshots
N/A

## Types of changes
- Bug fix
