### PR TITLE
Restore `$wpdb->use_mysqli` for backward compatibility

### DIFF
--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -691,6 +691,16 @@ class wpdb {
 	private $allow_unsafe_unquoted_parameters = true;
 
 	/**
+	 * Whether to use mysqli over mysql. Default false.
+	 *
+	 * @since 3.9.0
+	 * @since CP-2.0.0 Defaults to true for backward compatibility.
+	 *
+	 * @var bool
+	 */
+	private $use_mysqli = true;
+
+	/**
 	 * Whether we've managed to successfully connect at some point.
 	 *
 	 * @since 3.9.0

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -2469,4 +2469,14 @@ class Tests_DB extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * The wpdb->use_mysqli is true (for now), purely for backwards compatibility reasons.
+	 */
+	public function test_mysqli_is_set() {
+		global $wpdb;
+
+		$this->assertObjectHasAttribute( 'use_mysqli', $wpdb );
+		$this->assertTrue( $wpdb->use_mysqli );
+	}
 }


### PR DESCRIPTION
## Description
Restore `$wpdb->use_mysqli` that was removed in #201 (WP-r56475).


## Motivation and context
- ClassicCommerce uses `$wpdb->use_mysqli` (wrongly because it's private) to check which function to use
- GitHub reports 1.4k results when searching for `$wpdb->use_mysqli`

## How has this been tested?
New unit tests in place.

## Types of changes
- Bug fix
