### PR TITLE
Update common.css to reinstate enlarged default marker for disclosure widget

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -2058,29 +2058,23 @@ html.wp-toolbar {
 	position: relative;
 }
 
-/* Replace default marker in details element */
+/* Enhance default marker in details element */
 details summary > * {
 	display: inline;
 }
 
 .metabox-holder details > summary {
-	list-style: none;
 	margin-top: -0.3em !important;
 }
 
-/* Addresses Safari issue, see v2 PR#217 */
+.metabox-holder details > summary::marker,
 .metabox-holder details > summary::-webkit-details-marker {
-	display: none;
-}
-
-.metabox-holder details > summary::before {
-	content: '\25B8';
 	font-size: 1.5em;
 	cursor: pointer;
 }
 
-.metabox-holder details[open] > summary::before {
-	content: '\25BE';
+.metabox-holder details > summary h2 {
+	padding-left: 5px !important;
 }
 
 #post-body-content {


### PR DESCRIPTION
We originally replaced the default disclosure widget marker because it was too small. But apparently some assistive technology looks at the marker instead of the status of the `open` attribute to determine whether the widget is open or closed! Yes, it's crazy! See https://www.scottohara.me/blog/2022/09/12/details-summary.html

This PR therefore reinstates the default marker but makes it bigger, which is probably a better idea anyway. It addresses dashboard widgets, post/page metaboxes, and menu items. I have already modified the PR currently under consideration for widgets.