### PR TITLE
Update deprecated PHPUnit assertions

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -859,7 +859,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 		$this->assertNotEmpty( $fields, $message . ' Fields array is empty.' );
 
 		foreach ( $fields as $field_name => $field_value ) {
-			$this->assertObjectHasAttribute( $field_name, $actual, $message . " Property $field_name does not exist on the object." );
+			$this->assertObjectHasProperty( $field_name, $actual, $message . " Property $field_name does not exist on the object." );
 			$this->assertSame( $field_value, $actual->$field_name, $message . " Value of property $field_name is not $field_value." );
 		}
 	}

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -476,7 +476,7 @@ class Tests_Comment extends WP_UnitTestCase {
 			'The comment is not an instance of WP_Comment.'
 		);
 
-		$this->assertObjectHasAttribute(
+		$this->assertObjectHasProperty(
 			'comment_author',
 			$comment,
 			'The comment object does not have a "comment_author" property.'

--- a/tests/phpunit/tests/customize/manager.php
+++ b/tests/phpunit/tests/customize/manager.php
@@ -3339,14 +3339,14 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 		$setting_id = 'dynamic';
 		$setting    = $manager->add_setting( $setting_id );
 		$this->assertSame( 'WP_Customize_Setting', get_class( $setting ) );
-		$this->assertObjectNotHasAttribute( 'custom', $setting );
+		$this->assertObjectNotHasProperty( 'custom', $setting );
 		$manager->remove_setting( $setting_id );
 
 		add_filter( 'customize_dynamic_setting_class', array( $this, 'return_dynamic_customize_setting_class' ), 10, 3 );
 		add_filter( 'customize_dynamic_setting_args', array( $this, 'return_dynamic_customize_setting_args' ), 10, 2 );
 		$setting = $manager->add_setting( $setting_id );
 		$this->assertSame( 'Test_Dynamic_Customize_Setting', get_class( $setting ) );
-		$this->assertObjectHasAttribute( 'custom', $setting );
+		$this->assertObjectHasProperty( 'custom', $setting );
 		$this->assertSame( 'foo', $setting->custom );
 	}
 

--- a/tests/phpunit/tests/customize/nav-menu-item-setting.php
+++ b/tests/phpunit/tests/customize/nav-menu-item-setting.php
@@ -926,17 +926,17 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$nav_menu_item = $setting->value_as_wp_post_nav_menu_item();
 		$this->assertSame( 'Custom Label', $nav_menu_item->type_label );
 
-		$this->assertObjectNotHasAttribute( 'nav_menu_term_id', $nav_menu_item );
-		$this->assertObjectNotHasAttribute( 'status', $nav_menu_item );
+		$this->assertObjectNotHasProperty( 'nav_menu_term_id', $nav_menu_item );
+		$this->assertObjectNotHasProperty( 'status', $nav_menu_item );
 		$this->assertSame( 'publish', $nav_menu_item->post_status );
 		$this->assertSame( 'nav_menu_item', $nav_menu_item->post_type );
-		$this->assertObjectNotHasAttribute( 'position', $nav_menu_item );
+		$this->assertObjectNotHasProperty( 'position', $nav_menu_item );
 		$this->assertSame( $post_value['position'], $nav_menu_item->menu_order );
 		$this->assertSame( $post_value['title'], $nav_menu_item->post_title );
 		$this->assertSame( 123, $nav_menu_item->ID );
 		$this->assertSame( 123, $nav_menu_item->db_id );
 		$this->assertSame( wp_get_current_user()->ID, $nav_menu_item->post_author );
-		$this->assertObjectHasAttribute( 'type_label', $nav_menu_item );
+		$this->assertObjectHasProperty( 'type_label', $nav_menu_item );
 		$expected = apply_filters( 'nav_menu_attr_title', wp_unslash( apply_filters( 'excerpt_save_pre', wp_slash( $post_value['attr_title'] ) ) ) );
 		$this->assertSame( $expected, $nav_menu_item->attr_title );
 		$this->assertSame( 'Attempted \o/ o&#8217;o markup', $nav_menu_item->description );
@@ -1070,7 +1070,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$this->assertSame( $original_post_title, $item_value['original_title'] );
 		$this->assertSame( '', $item_value['title'] );
 		$item = $setting->value_as_wp_post_nav_menu_item();
-		$this->assertObjectHasAttribute( 'type_label', $item );
+		$this->assertObjectHasProperty( 'type_label', $item );
 		$this->assertSame( $original_post_title, $item->original_title );
 		$this->assertSame( $original_post_title, $item->title );
 		$this->assertArrayHasKey( 'type_label', $item_value );
@@ -1097,7 +1097,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$this->assertSame( $original_post_title, $item_value['original_title'] );
 		$this->assertSame( '', $item_value['title'] );
 		$item = $setting->value_as_wp_post_nav_menu_item();
-		$this->assertObjectHasAttribute( 'type_label', $item );
+		$this->assertObjectHasProperty( 'type_label', $item );
 		$this->assertSame( $original_post_title, $item->original_title );
 		$this->assertSame( $original_post_title, $item->title );
 		$this->assertArrayHasKey( 'type_label', $item_value );
@@ -1124,7 +1124,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$this->assertSame( $original_term_title, $item_value['original_title'] );
 		$this->assertSame( '', $item_value['title'] );
 		$item = $setting->value_as_wp_post_nav_menu_item();
-		$this->assertObjectHasAttribute( 'type_label', $item );
+		$this->assertObjectHasProperty( 'type_label', $item );
 		$this->assertSame( $original_term_title, $item->original_title );
 		$this->assertSame( $original_term_title, $item->title );
 		$this->assertArrayHasKey( 'type_label', $item_value );
@@ -1151,7 +1151,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$this->assertSame( $original_term_title, $item_value['original_title'] );
 		$this->assertSame( '', $item_value['title'] );
 		$item = $setting->value_as_wp_post_nav_menu_item();
-		$this->assertObjectHasAttribute( 'type_label', $item );
+		$this->assertObjectHasProperty( 'type_label', $item );
 		$this->assertSame( $original_term_title, $item->original_title );
 		$this->assertSame( $original_term_title, $item->title );
 		$this->assertArrayHasKey( 'type_label', $item_value );
@@ -1177,7 +1177,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$this->assertSame( get_post_type_object( 'press_release' )->labels->archives, $item_value['original_title'] );
 		$this->assertSame( '', $item_value['title'] );
 		$item = $setting->value_as_wp_post_nav_menu_item();
-		$this->assertObjectHasAttribute( 'type_label', $item );
+		$this->assertObjectHasProperty( 'type_label', $item );
 		$this->assertSame( get_post_type_object( 'press_release' )->labels->archives, $item->original_title );
 		$this->assertSame( get_post_type_object( 'press_release' )->labels->archives, $item->title );
 		$this->assertArrayHasKey( 'type_label', $item_value );
@@ -1203,7 +1203,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$this->assertSame( get_post_type_object( 'press_release' )->labels->archives, $item_value['original_title'] );
 		$this->assertSame( '', $item_value['title'] );
 		$item = $setting->value_as_wp_post_nav_menu_item();
-		$this->assertObjectHasAttribute( 'type_label', $item );
+		$this->assertObjectHasProperty( 'type_label', $item );
 		$this->assertSame( get_post_type_object( 'press_release' )->labels->archives, $item->original_title );
 		$this->assertSame( get_post_type_object( 'press_release' )->labels->archives, $item->title );
 		$this->assertArrayHasKey( 'type_label', $item_value );

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -2476,7 +2476,7 @@ class Tests_DB extends WP_UnitTestCase {
 	public function test_mysqli_is_set() {
 		global $wpdb;
 
-		$this->assertObjectHasAttribute( 'use_mysqli', $wpdb );
+		$this->assertObjectHasProperty( 'use_mysqli', $wpdb );
 		$this->assertTrue( $wpdb->use_mysqli );
 	}
 }

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -236,7 +236,7 @@ class Tests_Post extends WP_UnitTestCase {
 		register_post_status( 'test' );
 
 		$counts = wp_count_posts();
-		$this->assertObjectHasAttribute( 'test', $counts );
+		$this->assertObjectHasProperty( 'test', $counts );
 		$this->assertSame( 0, $counts->test );
 	}
 

--- a/tests/phpunit/tests/post/getPostTypeLabels.php
+++ b/tests/phpunit/tests/post/getPostTypeLabels.php
@@ -95,9 +95,9 @@ class Tests_Post_GetPostTypeLabels extends WP_UnitTestCase {
 
 		unregister_post_type( 'foo' );
 
-		$this->assertObjectHasAttribute( 'labels', $post_type_object );
-		$this->assertObjectHasAttribute( 'label', $post_type_object );
-		$this->assertObjectHasAttribute( 'not_found_in_trash', $post_type_object->labels );
+		$this->assertObjectHasProperty( 'labels', $post_type_object );
+		$this->assertObjectHasProperty( 'label', $post_type_object );
+		$this->assertObjectHasProperty( 'not_found_in_trash', $post_type_object->labels );
 	}
 
 	public function test_label_should_be_derived_from_labels_when_registering_a_post_type() {
@@ -122,8 +122,8 @@ class Tests_Post_GetPostTypeLabels extends WP_UnitTestCase {
 		add_filter( 'post_type_labels_foo', array( $this, 'filter_post_type_labels' ) );
 		register_post_type( 'foo' );
 
-		$this->assertObjectHasAttribute( 'featured_image', get_post_type_object( 'foo' )->labels );
-		$this->assertObjectHasAttribute( 'set_featured_image', get_post_type_object( 'foo' )->labels );
+		$this->assertObjectHasProperty( 'featured_image', get_post_type_object( 'foo' )->labels );
+		$this->assertObjectHasProperty( 'set_featured_image', get_post_type_object( 'foo' )->labels );
 
 		unregister_post_type( 'foo' );
 		remove_filter( 'post_type_labels_foo', array( $this, 'filter_post_type_labels' ) );

--- a/tests/phpunit/tests/post/updatePostCache.php
+++ b/tests/phpunit/tests/post/updatePostCache.php
@@ -57,7 +57,7 @@ class Tests_Post_UpdatePostCache extends WP_UnitTestCase {
 			'The cached post is not an object'
 		);
 
-		$this->assertObjectHasAttribute(
+		$this->assertObjectHasProperty(
 			'filter',
 			$cached_post,
 			'The cached post does not have a "filter" property'
@@ -98,7 +98,7 @@ class Tests_Post_UpdatePostCache extends WP_UnitTestCase {
 			'The cached post is not an object'
 		);
 
-		$this->assertObjectHasAttribute(
+		$this->assertObjectHasProperty(
 			'filter',
 			$cached_post,
 			'The cached post does not have a "filter" property'
@@ -126,7 +126,7 @@ class Tests_Post_UpdatePostCache extends WP_UnitTestCase {
 			'The cached post is not an object'
 		);
 
-		$this->assertObjectHasAttribute(
+		$this->assertObjectHasProperty(
 			'filter',
 			$cached_post,
 			'The cached post does not have a "filter" property'

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -1257,7 +1257,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 
 		$result = json_decode( rest_get_server()->sent_body );
 
-		$this->assertObjectNotHasAttribute( 'code', $result );
+		$this->assertObjectNotHasProperty( 'code', $result );
 	}
 
 	public function test_link_header_on_requests() {

--- a/tests/phpunit/tests/taxonomy.php
+++ b/tests/phpunit/tests/taxonomy.php
@@ -284,7 +284,7 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 		// Create a post type to test with.
 		$post_type = 'test_cpt';
 		$this->assertFalse( get_post_type( $post_type ) );
-		$this->assertObjectHasAttribute( 'name', register_post_type( $post_type ) );
+		$this->assertObjectHasProperty( 'name', register_post_type( $post_type ) );
 
 		// Core taxonomy, core post type.
 		$this->assertTrue( unregister_taxonomy_for_object_type( 'category', 'post' ) );

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -362,7 +362,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 		$this->assertNotEmpty( $terms );
 		foreach ( $terms as $term ) {
 			$this->assertInstanceOf( 'WP_Term', $term );
-			$this->assertObjectHasAttribute( 'object_id', $term );
+			$this->assertObjectHasProperty( 'object_id', $term );
 		}
 
 		// Run again to check the cached response.
@@ -370,7 +370,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 		$this->assertNotEmpty( $terms );
 		foreach ( $terms as $term ) {
 			$this->assertInstanceOf( 'WP_Term', $term );
-			$this->assertObjectHasAttribute( 'object_id', $term );
+			$this->assertObjectHasProperty( 'object_id', $term );
 		}
 	}
 

--- a/tests/phpunit/tests/term/wpGetObjectTerms.php
+++ b/tests/phpunit/tests/term/wpGetObjectTerms.php
@@ -858,7 +858,7 @@ class Tests_Term_WpGetObjectTerms extends WP_UnitTestCase {
 		}
 
 		$term = get_term( $t );
-		$this->assertObjectNotHasAttribute( 'object_id', $term );
+		$this->assertObjectNotHasProperty( 'object_id', $term );
 	}
 
 	/**

--- a/tests/phpunit/tests/user/multisite.php
+++ b/tests/phpunit/tests/user/multisite.php
@@ -59,15 +59,15 @@ if ( is_multisite() ) :
 			// Each site retrieved should match the expected structure.
 			foreach ( $blogs_of_user as $blog_id => $blog ) {
 				$this->assertSame( $blog_id, $blog->userblog_id );
-				$this->assertObjectHasAttribute( 'userblog_id', $blog );
-				$this->assertObjectHasAttribute( 'blogname', $blog );
-				$this->assertObjectHasAttribute( 'domain', $blog );
-				$this->assertObjectHasAttribute( 'path', $blog );
-				$this->assertObjectHasAttribute( 'site_id', $blog );
-				$this->assertObjectHasAttribute( 'siteurl', $blog );
-				$this->assertObjectHasAttribute( 'archived', $blog );
-				$this->assertObjectHasAttribute( 'spam', $blog );
-				$this->assertObjectHasAttribute( 'deleted', $blog );
+				$this->assertObjectHasProperty( 'userblog_id', $blog );
+				$this->assertObjectHasProperty( 'blogname', $blog );
+				$this->assertObjectHasProperty( 'domain', $blog );
+				$this->assertObjectHasProperty( 'path', $blog );
+				$this->assertObjectHasProperty( 'site_id', $blog );
+				$this->assertObjectHasProperty( 'siteurl', $blog );
+				$this->assertObjectHasProperty( 'archived', $blog );
+				$this->assertObjectHasProperty( 'spam', $blog );
+				$this->assertObjectHasProperty( 'deleted', $blog );
 			}
 
 			// Mark each remaining site as spam, archived, and deleted.


### PR DESCRIPTION
## Description
PHPUnit 10 will deprecate `assertObjectHasAttribute` and `assertObjectNotHasAttribute` in favour of `assertObjectHasProperty` and `assertObjectNotHasProperty`. This PR switches all instances of usage of the deprecated assertions to the new assertion functions.

## Motivation and context
Tests are currently unaffected but this PR will remove some reported warnings and make migrating to PHPUnit 10 easier when we are ready. We reduce from 47 tests with warnings to 32.

## How has this been tested?
Local Testing

## Screenshots
### Before
<img width="537" alt="Screenshot 2023-10-10 at 17 41 44" src="https://github.com/ClassicPress/ClassicPress-v2/assets/1280733/aa371734-5ed5-414a-9181-81daa0fc6e8b">

### After
<img width="536" alt="Screenshot 2023-10-10 at 17 39 35" src="https://github.com/ClassicPress/ClassicPress-v2/assets/1280733/bf1dab72-66d7-4376-9d2b-0a14a5f15670">

## Types of changes
- Bug fix