### PR TITLE
Fix undefined var after default to HTML5 

### DIFF
--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -1857,7 +1857,7 @@ function _custom_background_cb() {
 		$style .= $image . $position . $size . $repeat . $attachment;
 	}
 	?>
-<style<?php echo $type_attr; ?> id="custom-background-css">
+<style id="custom-background-css">
 body.custom-background { <?php echo trim( $style ); ?> }
 </style>
 	<?php


### PR DESCRIPTION
After #200 seems that [in this line](https://github.com/ClassicPress/ClassicPress-v2/blob/0323c525e1e99704746696ab46a60451c1dbb24a/src/wp-includes/theme.php#L1860) `$type_attr` is undefined (it's the only recurrence of this var in the file).

## Motivation and context
On a live site I get:

<img width="817" alt="image" src="https://github.com/ClassicPress/ClassicPress-v2/assets/29772709/a94721e6-af24-46a5-9db0-34080deffd4d">

## How has this been tested?
Can't reproduce the issue.

## Types of changes
- Bug fix