### PR TITLE
Make up/down buttons work again on dashboard and post screens

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -2038,14 +2038,19 @@ html.wp-toolbar {
 .postbox-container summary {
 	font-size: 14px;
 	font-weight: 600;
-	padding: 8px 12px;
+	padding: 2px 12px;
 	margin: 0;
 	line-height: 1.4;
 	border-bottom: 1px solid #c3c4c7;
 }
 
+.postbox-container summary > div {
+	display: inline-flex;
+}
+
 .postbox-container .handle-actions {
-	float: right;
+	right: 12px;
+	position: absolute;
 }
 
 #wpbody-content .metabox-holder {
@@ -2061,10 +2066,6 @@ html.wp-toolbar {
 /* Enhance default marker in details element */
 details summary > * {
 	display: inline;
-}
-
-.metabox-holder details > summary {
-	margin-top: -0.3em !important;
 }
 
 .metabox-holder details > summary::marker,

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -645,7 +645,7 @@ form#tags-filter {
 
 #poststuff summary {
 	font-size: 14px;
-	padding: 8px 12px;
+	padding: 2px 12px;
 	margin: 0;
 	line-height: 1.4;
 }

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1277,6 +1277,7 @@ function do_meta_boxes( $screen, $context, $data_object ) {
 					echo '<details id="' . $box['id'] . '" class="postbox' . $hidden_class . '"' . $open_attribute . '>' . "\n";
 
 					echo '<summary>';
+					echo '<div>';
 					echo '<h2 class="hndle">';
 
 					if ( 'dashboard_php_nag' === $box['id'] ) {
@@ -1287,6 +1288,7 @@ function do_meta_boxes( $screen, $context, $data_object ) {
 						' </span>';
 					}
 					echo $box['title'];
+					echo '</h2>';
 
 					if ( 'dashboard_browser_nag' !== $box['id'] ) {
 						$widget_title = $box['title'];
@@ -1327,8 +1329,7 @@ function do_meta_boxes( $screen, $context, $data_object ) {
 
 						echo '</span>';
 					}
-
-					echo '</h2>';
+					echo '</div>';
 					echo "</summary>\n";
 
 					echo '<div class="inside" style="display:block">' . "\n";


### PR DESCRIPTION
This is a fix caused by the recent change from JavaScript-based widgets to use of the native HTML5 disclosure widget on the admin dashboard and post edit screens.

The buttons (represented by arrows) in the top right-hand corner of each widget had effectively been deactivated by those changes, and the appearance of the widgets on webkit-based browsers was sub-optimal. This PR corrects those issues by adding a new `div` within the `summary` element and then taking the buttons out of the `h2` tag. It also adjusts the CSS accordingly.