### PR TITLE
Update actions/checkout action to specify v4

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+        uses: actions/checkout@v4
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+        uses: actions/checkout@v4
 
       - name: Read .nvmrc
         run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -32,7 +32,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+        uses: actions/checkout@v4
 
       - name: Read .nvmrc
         run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+        uses: actions/checkout@v4
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -66,7 +66,7 @@ jobs:
           echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
 
       - name: Checkout repository
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+        uses: actions/checkout@v4
 
       - name: Read .nvmrc
         run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -8,7 +8,7 @@ jobs:
   add_label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - uses: actions/checkout@v4
       - uses: actions-ecosystem/action-add-labels@v1
         if: github.event.issue.labels[0] == null
         with:


### PR DESCRIPTION
## Description
According to the [Dependency Dashboard](https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2FClassicPress%2FClassicPress-v2%2Fpull%2Fnew%2Fdevelop...fix%252Fworkflow-checkout), Renovate is currently failing when checking the versions of some actions used in the automated checks on GitHub. This seems to be due to a change from a version number to a specific commit point that was introduced by Renovate in PRs #199 and #223

<img width="808" alt="Screenshot 2023-10-18 at 17 11 18" src="https://github.com/ClassicPress/ClassicPress-v2/assets/1280733/00d111bf-1f89-452e-878f-67b8145d565d">

## Motivation and context
This PR reverts to a more simplistic implementattion specifyins `actions/checkout@v4`

## How has this been tested?
Unit Tests will run on this PR.

## Screenshots
N/A

## Types of changes
- Bug fix
