### PR TITLE
WP-r55607: Comments: Use wp_cache_get_multiple in WP_Comment_Query

### DIFF
--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -1038,23 +1038,18 @@ class WP_Comment_Query {
 			$_parent_ids         = $levels[ $level ];
 			if ( $_parent_ids ) {
 				$cache_keys = array();
-			foreach ( $_parent_ids as $parent_id ) {
-<<<<<<< HEAD
-				$cache_key        = "get_comment_child_ids:$parent_id:$key:$last_changed";
-				$parent_child_ids = wp_cache_get( $cache_key, 'comment' );
-=======
+				foreach ( $_parent_ids as $parent_id ) {
 					$cache_keys[ $parent_id ] = "get_comment_child_ids:$parent_id:$key:$last_changed";
 				}
 				$cache_data = wp_cache_get_multiple( array_values( $cache_keys ), 'comment-queries' );
 				foreach ( $_parent_ids as $parent_id ) {
 					$parent_child_ids = $cache_data[ $cache_keys[ $parent_id ] ];
->>>>>>> c46a30eb1f (Comments: Use wp_cache_get_multiple in `WP_Comment_Query`.)
-				if ( false !== $parent_child_ids ) {
-					$child_ids = array_merge( $child_ids, $parent_child_ids );
-				} else {
-					$uncached_parent_ids[] = $parent_id;
+					if ( false !== $parent_child_ids ) {
+						$child_ids = array_merge( $child_ids, $parent_child_ids );
+					} else {
+						$uncached_parent_ids[] = $parent_id;
+					}
 				}
-			}
 			}
 
 			if ( $uncached_parent_ids ) {

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -1036,14 +1036,25 @@ class WP_Comment_Query {
 			$child_ids           = array();
 			$uncached_parent_ids = array();
 			$_parent_ids         = $levels[ $level ];
+			if ( $_parent_ids ) {
+				$cache_keys = array();
 			foreach ( $_parent_ids as $parent_id ) {
+<<<<<<< HEAD
 				$cache_key        = "get_comment_child_ids:$parent_id:$key:$last_changed";
 				$parent_child_ids = wp_cache_get( $cache_key, 'comment' );
+=======
+					$cache_keys[ $parent_id ] = "get_comment_child_ids:$parent_id:$key:$last_changed";
+				}
+				$cache_data = wp_cache_get_multiple( array_values( $cache_keys ), 'comment-queries' );
+				foreach ( $_parent_ids as $parent_id ) {
+					$parent_child_ids = $cache_data[ $cache_keys[ $parent_id ] ];
+>>>>>>> c46a30eb1f (Comments: Use wp_cache_get_multiple in `WP_Comment_Query`.)
 				if ( false !== $parent_child_ids ) {
 					$child_ids = array_merge( $child_ids, $parent_child_ids );
 				} else {
 					$uncached_parent_ids[] = $parent_id;
 				}
+			}
 			}
 
 			if ( $uncached_parent_ids ) {


### PR DESCRIPTION
## Description
Comments: Use wp_cache_get_multiple in WP_Comment_Query.

In the fill_descendants method in WP_Comment_Query, there is a loop the calls wp_cache_get to get child comments. Instead of getting one key at a time, use wp_cache_get_multiple` and get all keys at once.

Props spacedmonkey, tillkruess, mukesh27.

https://core.trac.wordpress.org/changeset/55607

## Motivation and context
Backport of upstream efficiency enhancement

## How has this been tested?
This is a backport, local tests have been passing.

## Screenshots
N/A

## Types of changes
- Code efficiency enhancement
