### PR TITLE
WP-r55888: Script Loader: Improve performance of wp_maybe_inline_styles function.

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2128,12 +2128,18 @@ function wp_maybe_inline_styles() {
 
 	// Build an array of styles that have a path defined.
 	foreach ( $wp_styles->queue as $handle ) {
-		if ( wp_styles()->get_data( $handle, 'path' ) && file_exists( $wp_styles->registered[ $handle ]->extra['path'] ) ) {
+		$src  = $wp_styles->registered[ $handle ]->src;
+		$path = wp_styles()->get_data( $handle, 'path' );
+		if ( $path && $src ) {
+			$size = wp_filesize( $path );
+			if ( ! $size ) {
+				continue;
+			}
 			$styles[] = array(
 				'handle' => $handle,
-				'src'    => $wp_styles->registered[ $handle ]->src,
-				'path'   => $wp_styles->registered[ $handle ]->extra['path'],
-				'size'   => filesize( $wp_styles->registered[ $handle ]->extra['path'] ),
+				'src'    => $src,
+				'path'   => $path,
+				'size'   => $size,
 			);
 		}
 	}

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2128,8 +2128,11 @@ function wp_maybe_inline_styles() {
 
 	// Build an array of styles that have a path defined.
 	foreach ( $wp_styles->queue as $handle ) {
+		if ( ! isset( $wp_styles->registered[ $handle ] ) ) {
+			continue;
+		}
 		$src  = $wp_styles->registered[ $handle ]->src;
-		$path = wp_styles()->get_data( $handle, 'path' );
+		$path = $wp_styles->get_data( $handle, 'path' );
 		if ( $path && $src ) {
 			$size = wp_filesize( $path );
 			if ( ! $size ) {

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -540,6 +540,26 @@ CSS;
 	}
 
 	/**
+	 * @ticket 58394
+	 *
+	 * @covers ::wp_maybe_inline_styles
+	 */
+	public function test_wp_maybe_inline_styles_dequeue_styles() {
+		$filter = new MockAction();
+		add_filter( 'pre_wp_filesize', array( $filter, 'filter' ) );
+		wp_register_style( 'test-handle', '/' . WPINC . '/css/classic-themes.css' );
+		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/classic-themes.css' );
+
+		wp_enqueue_style( 'test-handle' );
+
+		wp_deregister_style( 'test-handle' );
+
+		wp_maybe_inline_styles();
+
+		$this->assertSame( 0, $filter->get_call_count() );
+	}
+
+	/**
 	 * wp_filesize should be only be called once, as on the second run of wp_maybe_inline_styles,
 	 * src will be set to false and filesize will not be requested.
 	 *

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -519,4 +519,207 @@ CSS;
 			),
 		);
 	}
+<<<<<<< HEAD
+=======
+
+	/**
+	 * Tests that visual block styles are not be enqueued in the editor when there is not theme support for 'wp-block-styles'.
+	 *
+	 * @ticket 57561
+	 *
+	 * @covers ::wp_enqueue_style
+	 */
+	public function test_block_styles_for_editing_without_theme_support() {
+		// Confirm we are without theme support by default.
+		$this->assertFalse( current_theme_supports( 'wp-block-styles' ) );
+
+		wp_default_styles( $GLOBALS['wp_styles'] );
+
+		$this->assertFalse( wp_style_is( 'wp-block-library-theme' ) );
+		wp_enqueue_style( 'wp-edit-blocks' );
+		$this->assertFalse( wp_style_is( 'wp-block-library-theme' ), "The 'wp-block-library-theme' style should not be in the queue after enqueuing 'wp-edit-blocks'" );
+	}
+
+	/**
+	 * Tests that visual block styles are enqueued when there is theme support for 'wp-block-styles'.
+	 *
+	 * Visual block styles should always be enqueued when editing to avoid the appearance of a broken editor.
+	 *
+	 * @covers ::wp_common_block_scripts_and_styles
+	 */
+	public function test_block_styles_for_editing_with_theme_support() {
+		add_theme_support( 'wp-block-styles' );
+
+		wp_default_styles( $GLOBALS['wp_styles'] );
+
+		$this->assertFalse( wp_style_is( 'wp-block-library-theme' ) );
+		wp_common_block_scripts_and_styles();
+		$this->assertTrue( wp_style_is( 'wp-block-library-theme' ) );
+	}
+
+	/**
+	 * Tests that visual block styles are not enqueued for viewing when there is no theme support for 'wp-block-styles'.
+	 *
+	 * Visual block styles should not be enqueued unless a theme opts in.
+	 * This way we avoid style conflicts with existing themes.
+	 *
+	 * @covers ::wp_enqueue_style
+	 */
+	public function test_no_block_styles_for_viewing_without_theme_support() {
+		// Confirm we are without theme support by default.
+		$this->assertFalse( current_theme_supports( 'wp-block-styles' ) );
+
+		wp_default_styles( $GLOBALS['wp_styles'] );
+
+		$this->assertFalse( wp_style_is( 'wp-block-library-theme' ) );
+		wp_enqueue_style( 'wp-block-library' );
+		$this->assertFalse( wp_style_is( 'wp-block-library-theme' ) );
+	}
+
+	/**
+	 * Tests that visual block styles are enqueued for viewing when there is theme support for 'wp-block-styles'.
+	 *
+	 * Visual block styles should be enqueued when a theme opts in.
+	 *
+	 * @covers ::wp_common_block_scripts_and_styles
+	 */
+	public function test_block_styles_for_viewing_with_theme_support() {
+		add_theme_support( 'wp-block-styles' );
+
+		wp_default_styles( $GLOBALS['wp_styles'] );
+
+		$this->assertFalse( wp_style_is( 'wp-block-library-theme' ) );
+		wp_common_block_scripts_and_styles();
+		$this->assertTrue( wp_style_is( 'wp-block-library-theme' ) );
+	}
+
+	/**
+	 * Tests that the main "style.css" file gets enqueued when the site doesn't opt in to separate core block assets.
+	 *
+	 * @ticket 50263
+	 *
+	 * @covers ::wp_default_styles
+	 */
+	public function test_block_styles_for_viewing_without_split_styles() {
+		add_filter( 'should_load_separate_core_block_assets', '__return_false' );
+		wp_default_styles( $GLOBALS['wp_styles'] );
+
+		$this->assertSame(
+			'/' . WPINC . '/css/dist/block-library/style.css',
+			$GLOBALS['wp_styles']->registered['wp-block-library']->src
+		);
+	}
+
+	/**
+	 * Tests that the "common.css" file gets enqueued when the site opts in to separate core block assets.
+	 *
+	 * @ticket 50263
+	 *
+	 * @covers ::wp_default_styles
+	 */
+	public function test_block_styles_for_viewing_with_split_styles() {
+		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
+		wp_default_styles( $GLOBALS['wp_styles'] );
+
+		$this->assertSame(
+			'/' . WPINC . '/css/dist/block-library/common.css',
+			$GLOBALS['wp_styles']->registered['wp-block-library']->src
+		);
+	}
+
+	/**
+	 * @ticket 58394
+	 *
+	 * @covers ::wp_maybe_inline_styles
+	 */
+	public function test_wp_maybe_inline_styles() {
+		wp_register_style( 'test-handle', '/' . WPINC . '/css/classic-themes.css' );
+		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/classic-themes.css' );
+
+		wp_enqueue_style( 'test-handle' );
+
+		wp_maybe_inline_styles();
+
+		$this->assertFalse( $GLOBALS['wp_styles']->registered['test-handle']->src, 'Source of style should be reset to false' );
+
+		$css = file_get_contents( ABSPATH . WPINC . '/css/classic-themes.css' );
+		$this->assertSameSets( $GLOBALS['wp_styles']->registered['test-handle']->extra['after'], array( $css ), 'Source of style should set to after property' );
+	}
+
+	/**
+	 * wp_filesize should be only be called once, as on the second run of wp_maybe_inline_styles,
+	 * src will be set to false and filesize will not be requested.
+	 *
+	 * @ticket 58394
+	 *
+	 * @covers ::wp_maybe_inline_styles
+	 */
+	public function test_wp_maybe_inline_styles_multiple_runs() {
+		$filter = new MockAction();
+		add_filter( 'pre_wp_filesize', array( $filter, 'filter' ) );
+		wp_register_style( 'test-handle', '/' . WPINC . '/css/classic-themes.css' );
+		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/classic-themes.css' );
+
+		wp_enqueue_style( 'test-handle' );
+
+		wp_maybe_inline_styles();
+		wp_maybe_inline_styles();
+
+		$this->assertSame( 1, $filter->get_call_count() );
+	}
+
+	/**
+	 * @ticket 58394
+	 *
+	 * @covers ::wp_maybe_inline_styles
+	 */
+	public function test_test_wp_maybe_inline_styles_missing_file() {
+		$filter = new MockAction();
+		add_filter( 'pre_wp_filesize', array( $filter, 'filter' ) );
+		$url = '/' . WPINC . '/css/invalid.css';
+		wp_register_style( 'test-handle', $url );
+		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/invalid.css' );
+
+		wp_enqueue_style( 'test-handle' );
+
+		wp_maybe_inline_styles();
+
+		$this->assertSame( $GLOBALS['wp_styles']->registered['test-handle']->src, $url, 'Source should not change' );
+		$this->assertArrayNotHasKey( 'after', $GLOBALS['wp_styles']->registered['test-handle']->extra, 'Source of style not should set to after property' );
+		$this->assertSame( 1, $filter->get_call_count(), 'wp_filesize should only be called once' );
+	}
+
+	/**
+	 * @ticket 58394
+	 *
+	 * @covers ::wp_maybe_inline_styles
+	 */
+	public function test_wp_maybe_inline_styles_no_src() {
+		wp_register_style( 'test-handle', false );
+		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/classic-themes.css' );
+
+		wp_enqueue_style( 'test-handle' );
+
+		wp_maybe_inline_styles();
+
+		$this->assertFalse( $GLOBALS['wp_styles']->registered['test-handle']->src, 'Source of style should remain false' );
+		$this->assertArrayNotHasKey( 'after', $GLOBALS['wp_styles']->registered['test-handle']->extra, 'Source of style not should set to after property' );
+	}
+
+	/**
+	 * @ticket 58394
+	 *
+	 * @covers ::wp_maybe_inline_styles
+	 */
+	public function test_wp_maybe_inline_styles_no_path() {
+		$url = '/' . WPINC . '/css/classic-themes.css';
+		wp_register_style( 'test-handle', $url );
+
+		wp_enqueue_style( 'test-handle' );
+
+		wp_maybe_inline_styles();
+
+		$this->assertSame( $GLOBALS['wp_styles']->registered['test-handle']->src, $url );
+	}
+>>>>>>> 582ddb82f4 (Script Loader: Improve performance of wp_maybe_inline_styles function. )
 }

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -519,113 +519,6 @@ CSS;
 			),
 		);
 	}
-<<<<<<< HEAD
-=======
-
-	/**
-	 * Tests that visual block styles are not be enqueued in the editor when there is not theme support for 'wp-block-styles'.
-	 *
-	 * @ticket 57561
-	 *
-	 * @covers ::wp_enqueue_style
-	 */
-	public function test_block_styles_for_editing_without_theme_support() {
-		// Confirm we are without theme support by default.
-		$this->assertFalse( current_theme_supports( 'wp-block-styles' ) );
-
-		wp_default_styles( $GLOBALS['wp_styles'] );
-
-		$this->assertFalse( wp_style_is( 'wp-block-library-theme' ) );
-		wp_enqueue_style( 'wp-edit-blocks' );
-		$this->assertFalse( wp_style_is( 'wp-block-library-theme' ), "The 'wp-block-library-theme' style should not be in the queue after enqueuing 'wp-edit-blocks'" );
-	}
-
-	/**
-	 * Tests that visual block styles are enqueued when there is theme support for 'wp-block-styles'.
-	 *
-	 * Visual block styles should always be enqueued when editing to avoid the appearance of a broken editor.
-	 *
-	 * @covers ::wp_common_block_scripts_and_styles
-	 */
-	public function test_block_styles_for_editing_with_theme_support() {
-		add_theme_support( 'wp-block-styles' );
-
-		wp_default_styles( $GLOBALS['wp_styles'] );
-
-		$this->assertFalse( wp_style_is( 'wp-block-library-theme' ) );
-		wp_common_block_scripts_and_styles();
-		$this->assertTrue( wp_style_is( 'wp-block-library-theme' ) );
-	}
-
-	/**
-	 * Tests that visual block styles are not enqueued for viewing when there is no theme support for 'wp-block-styles'.
-	 *
-	 * Visual block styles should not be enqueued unless a theme opts in.
-	 * This way we avoid style conflicts with existing themes.
-	 *
-	 * @covers ::wp_enqueue_style
-	 */
-	public function test_no_block_styles_for_viewing_without_theme_support() {
-		// Confirm we are without theme support by default.
-		$this->assertFalse( current_theme_supports( 'wp-block-styles' ) );
-
-		wp_default_styles( $GLOBALS['wp_styles'] );
-
-		$this->assertFalse( wp_style_is( 'wp-block-library-theme' ) );
-		wp_enqueue_style( 'wp-block-library' );
-		$this->assertFalse( wp_style_is( 'wp-block-library-theme' ) );
-	}
-
-	/**
-	 * Tests that visual block styles are enqueued for viewing when there is theme support for 'wp-block-styles'.
-	 *
-	 * Visual block styles should be enqueued when a theme opts in.
-	 *
-	 * @covers ::wp_common_block_scripts_and_styles
-	 */
-	public function test_block_styles_for_viewing_with_theme_support() {
-		add_theme_support( 'wp-block-styles' );
-
-		wp_default_styles( $GLOBALS['wp_styles'] );
-
-		$this->assertFalse( wp_style_is( 'wp-block-library-theme' ) );
-		wp_common_block_scripts_and_styles();
-		$this->assertTrue( wp_style_is( 'wp-block-library-theme' ) );
-	}
-
-	/**
-	 * Tests that the main "style.css" file gets enqueued when the site doesn't opt in to separate core block assets.
-	 *
-	 * @ticket 50263
-	 *
-	 * @covers ::wp_default_styles
-	 */
-	public function test_block_styles_for_viewing_without_split_styles() {
-		add_filter( 'should_load_separate_core_block_assets', '__return_false' );
-		wp_default_styles( $GLOBALS['wp_styles'] );
-
-		$this->assertSame(
-			'/' . WPINC . '/css/dist/block-library/style.css',
-			$GLOBALS['wp_styles']->registered['wp-block-library']->src
-		);
-	}
-
-	/**
-	 * Tests that the "common.css" file gets enqueued when the site opts in to separate core block assets.
-	 *
-	 * @ticket 50263
-	 *
-	 * @covers ::wp_default_styles
-	 */
-	public function test_block_styles_for_viewing_with_split_styles() {
-		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
-		wp_default_styles( $GLOBALS['wp_styles'] );
-
-		$this->assertSame(
-			'/' . WPINC . '/css/dist/block-library/common.css',
-			$GLOBALS['wp_styles']->registered['wp-block-library']->src
-		);
-	}
 
 	/**
 	 * @ticket 58394
@@ -633,8 +526,8 @@ CSS;
 	 * @covers ::wp_maybe_inline_styles
 	 */
 	public function test_wp_maybe_inline_styles() {
-		wp_register_style( 'test-handle', '/' . WPINC . '/css/classic-themes.css' );
-		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/classic-themes.css' );
+		wp_register_style( 'test-handle', '/' . WPINC . '/css/dashicons.css' );
+		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/dashicons.css' );
 
 		wp_enqueue_style( 'test-handle' );
 
@@ -642,7 +535,7 @@ CSS;
 
 		$this->assertFalse( $GLOBALS['wp_styles']->registered['test-handle']->src, 'Source of style should be reset to false' );
 
-		$css = file_get_contents( ABSPATH . WPINC . '/css/classic-themes.css' );
+		$css = file_get_contents( ABSPATH . WPINC . '/css/dashicons.css' );
 		$this->assertSameSets( $GLOBALS['wp_styles']->registered['test-handle']->extra['after'], array( $css ), 'Source of style should set to after property' );
 	}
 
@@ -657,8 +550,8 @@ CSS;
 	public function test_wp_maybe_inline_styles_multiple_runs() {
 		$filter = new MockAction();
 		add_filter( 'pre_wp_filesize', array( $filter, 'filter' ) );
-		wp_register_style( 'test-handle', '/' . WPINC . '/css/classic-themes.css' );
-		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/classic-themes.css' );
+		wp_register_style( 'test-handle', '/' . WPINC . '/css/dashicons.css' );
+		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/dashicons.css' );
 
 		wp_enqueue_style( 'test-handle' );
 
@@ -696,7 +589,7 @@ CSS;
 	 */
 	public function test_wp_maybe_inline_styles_no_src() {
 		wp_register_style( 'test-handle', false );
-		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/classic-themes.css' );
+		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/dashicons.css' );
 
 		wp_enqueue_style( 'test-handle' );
 
@@ -712,7 +605,7 @@ CSS;
 	 * @covers ::wp_maybe_inline_styles
 	 */
 	public function test_wp_maybe_inline_styles_no_path() {
-		$url = '/' . WPINC . '/css/classic-themes.css';
+		$url = '/' . WPINC . '/css/dashicons.css';
 		wp_register_style( 'test-handle', $url );
 
 		wp_enqueue_style( 'test-handle' );
@@ -721,5 +614,4 @@ CSS;
 
 		$this->assertSame( $GLOBALS['wp_styles']->registered['test-handle']->src, $url );
 	}
->>>>>>> 582ddb82f4 (Script Loader: Improve performance of wp_maybe_inline_styles function. )
 }

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -526,8 +526,8 @@ CSS;
 	 * @covers ::wp_maybe_inline_styles
 	 */
 	public function test_wp_maybe_inline_styles() {
-		wp_register_style( 'test-handle', '/' . WPINC . '/css/dashicons.css' );
-		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/dashicons.css' );
+		wp_register_style( 'test-handle', '/' . WPINC . '/css/wp-pointer.css' );
+		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/wp-pointer.css' );
 
 		wp_enqueue_style( 'test-handle' );
 
@@ -535,7 +535,7 @@ CSS;
 
 		$this->assertFalse( $GLOBALS['wp_styles']->registered['test-handle']->src, 'Source of style should be reset to false' );
 
-		$css = file_get_contents( ABSPATH . WPINC . '/css/dashicons.css' );
+		$css = file_get_contents( ABSPATH . WPINC . '/css/wp-pointer.css' );
 		$this->assertSameSets( $GLOBALS['wp_styles']->registered['test-handle']->extra['after'], array( $css ), 'Source of style should set to after property' );
 	}
 
@@ -547,8 +547,8 @@ CSS;
 	public function test_wp_maybe_inline_styles_dequeue_styles() {
 		$filter = new MockAction();
 		add_filter( 'pre_wp_filesize', array( $filter, 'filter' ) );
-		wp_register_style( 'test-handle', '/' . WPINC . '/css/classic-themes.css' );
-		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/classic-themes.css' );
+		wp_register_style( 'test-handle', '/' . WPINC . '/css/wp-pointer.css' );
+		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/wp-pointer.css' );
 
 		wp_enqueue_style( 'test-handle' );
 
@@ -570,8 +570,8 @@ CSS;
 	public function test_wp_maybe_inline_styles_multiple_runs() {
 		$filter = new MockAction();
 		add_filter( 'pre_wp_filesize', array( $filter, 'filter' ) );
-		wp_register_style( 'test-handle', '/' . WPINC . '/css/dashicons.css' );
-		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/dashicons.css' );
+		wp_register_style( 'test-handle', '/' . WPINC . '/css/wp-pointer.css' );
+		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/wp-pointer.css' );
 
 		wp_enqueue_style( 'test-handle' );
 
@@ -609,7 +609,7 @@ CSS;
 	 */
 	public function test_wp_maybe_inline_styles_no_src() {
 		wp_register_style( 'test-handle', false );
-		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/dashicons.css' );
+		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/wp-pointer.css' );
 
 		wp_enqueue_style( 'test-handle' );
 
@@ -625,7 +625,7 @@ CSS;
 	 * @covers ::wp_maybe_inline_styles
 	 */
 	public function test_wp_maybe_inline_styles_no_path() {
-		$url = '/' . WPINC . '/css/dashicons.css';
+		$url = '/' . WPINC . '/css/wp-pointer.css';
 		wp_register_style( 'test-handle', $url );
 
 		wp_enqueue_style( 'test-handle' );


### PR DESCRIPTION
## Description
 Script Loader: Improve performance of wp_maybe_inline_styles function.

The wp_maybe_inline_styles function is called twice on the average page load. On it's second run however, it did not check to see if the style had already been processed on the first run. This resulted in calling filesize and get_file_contents unnecessarily, which was bad for performance. Now, the loop around the queued styles, checks to see if the source is set to false, meaning it has already been processed. This change also replaces calls to filesize with the core function wp_filesize, which improves extensibility.

Props spacedmonkey, flixos90, peterwilsoncc, joemcgill.

https://core.trac.wordpress.org/changeset/55888

## Motivation and context
Backport of upstream efficiency enhancement

## How has this been tested?
This is a backport, local tests have been passing.

## Screenshots
N/A

## Types of changes
- Code efficiency enhancement
