### PR TITLE
Tinymce in text widget

### DIFF
--- a/src/wp-admin/css/widgets.css
+++ b/src/wp-admin/css/widgets.css
@@ -1,7 +1,7 @@
 /* General Widgets Styles */
 
 .widget {
-	margin: 0 auto 10px;
+	margin: 0 auto 10px !important;
 	position: relative;
 	box-sizing: border-box;
 }

--- a/src/wp-admin/js/customize-widgets.js
+++ b/src/wp-admin/js/customize-widgets.js
@@ -1400,7 +1400,7 @@
 		 * @param {Object} args  merged on top of this.defaultActiveArguments
 		 */
 		onChangeExpanded: function ( expanded, args ) {
-			var self = this, $widget, $inside, complete, prevComplete, expandControl, $details;
+			var self = this, $widget, $inside, complete, prevComplete, expandControl, $details, $allWidgets;
 
 			self.embedWidgetControl(); // Make sure the outer form is embedded so that the expanded state can be set in the UI.
 			if ( expanded ) {
@@ -1421,18 +1421,12 @@
 			$inside = $widget.find( '.widget-inside:first' );
 			$details = $widget.children( 'details' );
 
+			// Close all other widget controls before expanding this one.
+			$allWidgets = $details.closest( 'ul' ).find( 'details');
+			$allWidgets.removeAttr( 'open' );
+
 			expandControl = function() {
 
-				// Close all other widget controls before expanding this one.
-				api.control.each( function( otherControl ) {
-					if ( self.params.type === otherControl.params.type && self !== otherControl ) {
-						otherControl.collapse();
-					}
-				} );
-
-				complete = function() {
-					$details.attr( 'open', 'open' );
-				};
 				if ( args.completeCallback ) {
 					prevComplete = complete;
 					complete = function () {
@@ -1440,18 +1434,13 @@
 						args.completeCallback();
 					};
 				}
-
-				if ( self.params.is_wide ) {
-					$inside.fadeIn( args.duration, complete );
-				} else {
-					$inside.slideDown( args.duration, complete );
-				}
+				$details.attr( 'open', 'open' );
 
 				self.container.trigger( 'expand' );
 				self.container.addClass( 'expanding' );
 			};
 
-			if ( ! $details[0].hasAttribute( 'open' ) ) {
+			if ( ! $details.attr( 'open' ) ) {
 				if ( api.section.has( self.section() ) ) {
 					api.section( self.section() ).expand( {
 						completeCallback: expandControl
@@ -1460,9 +1449,6 @@
 					expandControl();
 				}
 			} else {
-				complete = function() {
-					$widget.removeAttr( 'open' );
-				};
 				if ( args.completeCallback ) {
 					prevComplete = complete;
 					complete = function () {
@@ -1472,15 +1458,7 @@
 				}
 
 				self.container.trigger( 'collapse' );
-
-				if ( self.params.is_wide ) {
-					$inside.fadeOut( args.duration, complete );
-				} else {
-					$inside.slideUp( args.duration, function() {
-						$widget.css( { width:'', margin:'' } );
-						complete();
-					} );
-				}
+				$widget.removeAttr( 'open' );
 			}
 		},
 

--- a/src/wp-admin/js/widgets/text-widgets.js
+++ b/src/wp-admin/js/widgets/text-widgets.js
@@ -95,7 +95,7 @@ wp.textWidgets = ( function( $ ) {
 				});
 
 				// Note that syncInput cannot be re-used because it will be destroyed with each widget-updated event.
-				fieldInput.val( control.syncContainer.find( '.sync-input.' + fieldName ).val() );
+				fieldInput.val( control.syncContainer.querySelector( '.sync-input.' + fieldName ).value );
 			});
 		},
 
@@ -216,7 +216,7 @@ wp.textWidgets = ( function( $ ) {
 			};
 
 			// Just-in-time force-update the hidden input fields.
-			control.syncContainer.closest( '.widget' ).find( '[name=savewidget]:first' ).on( 'click', function onClickSaveButton() {
+			control.syncContainer.closest( '.widget' ).querySelector( '[name=savewidget]' ).addEventListener( 'click', function onClickSaveButton() {
 				triggerChangeIfDirty();
 			});
 
@@ -381,19 +381,23 @@ wp.textWidgets = ( function( $ ) {
 		var widgetForm, idBase, widgetControl, widgetId, animatedCheckDelay = 50, renderWhenAnimationDone, fieldContainer, syncContainer;
 		widgetForm = widgetContainer.find( '> .widget-inside > .form, > .widget-inside > form' ); // Note: '.form' appears in the customizer, whereas 'form' on the widgets admin screen.
 
-		idBase = widgetContainer.find( '.id_base' ).val();
+		if ( widgetContainer instanceof jQuery ) {
+			widgetContainer = widgetContainer[0];
+		}
+
+		idBase = widgetContainer.querySelector( '.id_base' ).value;
 		if ( -1 === component.idBases.indexOf( idBase ) ) {
 			return;
 		}
 
 		// Prevent initializing already-added widgets.
-		widgetId = widgetForm.find( '.widget-id' ).val();
+		widgetId = widgetContainer.querySelector( '.widget-id' ).value;
 		if ( component.widgetControls[ widgetId ] ) {
 			return;
 		}
 
 		// Bypass using TinyMCE when widget is in legacy mode.
-		if ( ! widgetContainer.find( '.visual' ).val() ) {
+		if ( ! widgetContainer.querySelector( '.visual' ).value ) {
 			return;
 		}
 
@@ -408,8 +412,8 @@ wp.textWidgets = ( function( $ ) {
 		 * components", the JS template is rendered outside of the normal form
 		 * container.
 		 */
-		fieldContainer = $( '<div></div>' );
-		syncContainer = widgetContainer.find( '.widget-content:first' );
+		fieldContainer = document.createElement( 'div' );
+		syncContainer = widgetContainer.querySelector( '.widget-content' );
 		syncContainer.before( fieldContainer );
 
 		widgetControl = new component.TextWidgetControl({
@@ -426,7 +430,7 @@ wp.textWidgets = ( function( $ ) {
 		 * with TinyMCE being able to set contenteditable on it.
 		 */
 		renderWhenAnimationDone = function() {
-			if ( ! widgetContainer.hasClass( 'open' ) ) {
+			if ( ! widgetContainer.querySelector( 'details' ).hasAttribute( 'open' ) ) {
 				setTimeout( renderWhenAnimationDone, animatedCheckDelay );
 			} else {
 				widgetControl.initializeEditor();
@@ -451,11 +455,6 @@ wp.textWidgets = ( function( $ ) {
 
 		idBase = widgetContainer.find( '.id_base' ).val();
 		if ( -1 === component.idBases.indexOf( idBase ) ) {
-			return;
-		}
-
-		// Bypass using TinyMCE when widget is in legacy mode.
-		if ( ! widgetForm.find( '.visual' ).val() ) {
 			return;
 		}
 

--- a/src/wp-admin/js/widgets/text-widgets.js
+++ b/src/wp-admin/js/widgets/text-widgets.js
@@ -392,6 +392,11 @@ wp.textWidgets = ( function( $ ) {
 			return;
 		}
 
+		// Bypass using TinyMCE when widget is in legacy mode.
+		if ( ! widgetContainer.find( '.visual' ).val() ) {
+			return;
+		}
+
 		/*
 		 * Create a container element for the widget control fields.
 		 * This is inserted into the DOM immediately before the .widget-content
@@ -446,6 +451,11 @@ wp.textWidgets = ( function( $ ) {
 
 		idBase = widgetContainer.find( '.id_base' ).val();
 		if ( -1 === component.idBases.indexOf( idBase ) ) {
+			return;
+		}
+
+		// Bypass using TinyMCE when widget is in legacy mode.
+		if ( ! widgetForm.find( '.visual' ).val() ) {
 			return;
 		}
 

--- a/src/wp-admin/js/widgets/text-widgets.js
+++ b/src/wp-admin/js/widgets/text-widgets.js
@@ -87,7 +87,7 @@ wp.textWidgets = ( function( $ ) {
 			// Sync input fields to hidden sync fields which actually get sent to the server.
 			_.each( control.fields, function( fieldInput, fieldName ) {
 				fieldInput.on( 'input change', function updateSyncField() {
-					var syncInput = control.syncContainer.find( '.sync-input.' + fieldName );
+					var syncInput = $(control.syncContainer).find( '.sync-input.' + fieldName );
 					if ( syncInput.val() !== fieldInput.val() ) {
 						syncInput.val( fieldInput.val() );
 						syncInput.trigger( 'change' );
@@ -95,7 +95,7 @@ wp.textWidgets = ( function( $ ) {
 				});
 
 				// Note that syncInput cannot be re-used because it will be destroyed with each widget-updated event.
-				fieldInput.val( control.syncContainer.querySelector( '.sync-input.' + fieldName ).value );
+				fieldInput.val( $(control.syncContainer).find( '.sync-input.' + fieldName ).val() );
 			});
 		},
 

--- a/src/wp-admin/js/widgets/text-widgets.js
+++ b/src/wp-admin/js/widgets/text-widgets.js
@@ -235,12 +235,18 @@ wp.textWidgets = ( function( $ ) {
 
 				// The user has disabled TinyMCE.
 				if ( typeof window.tinymce === 'undefined' ) {
+					wp.oldEditor.initialize( id, {
+						quicktags: true,
+						mediaButtons: true
+					});
+
 					return;
 				}
 
 				// Destroy any existing editor so that it can be re-initialized after a widget-updated event.
 				if ( tinymce.get( id ) ) {
 					restoreTextMode = tinymce.get( id ).isHidden();
+					wp.oldEditor.remove( id );
 				}
 
 				// Add or enable the `wpview` plugin.
@@ -252,6 +258,14 @@ wp.textWidgets = ( function( $ ) {
 					} else if ( ! /\bwpview\b/.test( init.plugins ) ) {
 						init.plugins += ',wpview';
 					}
+				} );
+
+				wp.oldEditor.initialize( id, {
+					tinymce: {
+						wpautop: true
+					},
+					quicktags: true,
+					mediaButtons: true
 				} );
 
 				/**

--- a/src/wp-admin/js/widgets/text-widgets.js
+++ b/src/wp-admin/js/widgets/text-widgets.js
@@ -378,7 +378,7 @@ wp.textWidgets = ( function( $ ) {
 	 * @return {void}
 	 */
 	component.handleWidgetAdded = function handleWidgetAdded( event, widgetContainer ) {
-		var widgetForm, idBase, widgetControl, widgetId, animatedCheckDelay = 50, renderWhenAnimationDone, fieldContainer, syncContainer;
+		var widgetForm, idBase, widgetControl, widgetId, animatedCheckDelay = 200, renderWhenAnimationDone, fieldContainer, syncContainer;
 		widgetForm = widgetContainer.find( '> .widget-inside > .form, > .widget-inside > form' ); // Note: '.form' appears in the customizer, whereas 'form' on the widgets admin screen.
 
 		if ( widgetContainer instanceof jQuery ) {

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -236,7 +236,6 @@ function wp_default_packages_inline_scripts( $scripts ) {
 		'after'
 	);
 
-	
 	// wp-editor module is exposed as window.wp.editor
 	// Problem: there is quite some code expecting window.wp.oldEditor object available under window.wp.editor
 	// Solution: fuse the two objects together to maintain backward compatibility

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -213,22 +213,6 @@ function wp_default_packages_inline_scripts( $scripts ) {
 		'after'
 	);
 
-	$scripts->add_inline_script(
-		'wp-data',
-		implode(
-			"\n",
-			array(
-				'( function() {',
-				'	var userId = ' . get_current_user_ID() . ';',
-				'	var storageKey = "WP_DATA_USER_" + userId;',
-				'	wp.data',
-				'		.use( wp.data.plugins.persistence, { storageKey: storageKey } );',
-				'	wp.data.plugins.persistence.__unstableMigrate( { storageKey: storageKey } );',
-				'} )();',
-			)
-		)
-	);
-
 	// Loading the old editor and its config to ensure the classic block works as expected.
 	$scripts->add_inline_script(
 		'editor',

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -229,54 +229,6 @@ function wp_default_packages_inline_scripts( $scripts ) {
 		)
 	);
 
-	// Calculate the timezone abbr (EDT, PST) if possible.
-	$timezone_string = get_option( 'timezone_string', 'UTC' );
-	$timezone_abbr   = '';
-	if ( ! empty( $timezone_string ) ) {
-		$timezone_date = new DateTime( null, new DateTimeZone( $timezone_string ) );
-		$timezone_abbr = $timezone_date->format( 'T' );
-	}
-	$scripts->add_inline_script(
-		'wp-date',
-		sprintf(
-			'wp.date.setSettings( %s );',
-			wp_json_encode(
-				array(
-					'l10n'     => array(
-						'locale'        => get_user_locale(),
-						'months'        => array_values( $wp_locale->month ),
-						'monthsShort'   => array_values( $wp_locale->month_abbrev ),
-						'weekdays'      => array_values( $wp_locale->weekday ),
-						'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
-						'meridiem'      => (object) $wp_locale->meridiem,
-						'relative'      => array(
-							/* translators: %s: Duration. */
-							'future' => __( '%s from now' ),
-							/* translators: %s: Duration. */
-							'past'   => __( '%s ago' ),
-						),
-					),
-					'formats'  => array(
-						/* translators: Time format, see https://www.php.net/manual/datetime.format.php */
-						'time'                => get_option( 'time_format', __( 'g:i a' ) ),
-						/* translators: Date format, see https://www.php.net/manual/datetime.format.php */
-						'date'                => get_option( 'date_format', __( 'F j, Y' ) ),
-						/* translators: Date/Time format, see https://www.php.net/manual/datetime.format.php */
-						'datetime'            => __( 'F j, Y g:i a' ),
-						/* translators: Abbreviated date/time format, see https://www.php.net/manual/datetime.format.php */
-						'datetimeAbbreviated' => __( 'M j, Y g:i a' ),
-					),
-					'timezone' => array(
-						'offset' => get_option( 'gmt_offset', 0 ),
-						'string' => $timezone_string,
-						'abbr'   => $timezone_abbr,
-					),
-				)
-			)
-		),
-		'after'
-	);
-
 	// Loading the old editor and its config to ensure the classic block works as expected.
 	$scripts->add_inline_script(
 		'editor',


### PR DESCRIPTION
This addresses Issue #273.

## Description
Adds back scripts that were omitted from `~/wp-includes/script-loader.php`. Also adds back code that was previously removed from `~wp-admin/js/widgets/text-widgets.js` because the lack of the missing scripts caused the widget otherwise to generate many errors.

## Motivation and context
This re-enables the usage of the TinyMCE editor in the text widget.

## How has this been tested?
On my localhost test installation.

## Screenshots
### Before
![Screenshot at 2023-10-31 16-53-14](https://github.com/ClassicPress/ClassicPress-v2/assets/4127662/721c6eae-8d84-48a1-848c-510898a21e31)

### After
![Screenshot at 2023-10-31 16-53-58](https://github.com/ClassicPress/ClassicPress-v2/assets/4127662/884ff563-601d-4ef5-8382-cbbe94d580e0)

## Types of changes
- Bug fix
